### PR TITLE
Add marker weather forecast

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -94,6 +94,7 @@ export default {
       APPWRITE_STORAGE_ID: process.env.APPWRITE_STORAGE_ID,
       ADMIN_EMAIL: process.env.ADMIN_EMAIL,
       ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
+      WEATHER_TEST_SCENARIO: process.env.WEATHER_TEST_SCENARIO,
     },
   },
 };

--- a/scripts/sync-markers-appwrite.js
+++ b/scripts/sync-markers-appwrite.js
@@ -22,8 +22,26 @@ const PRIMARY_SEED_PATH = path.join(repoRoot, "new-markers.json");
 const FALLBACK_SEED_PATH = path.join(repoRoot, "test-run-unique.json");
 const SEED_PATH = fs.existsSync(PRIMARY_SEED_PATH)
   ? PRIMARY_SEED_PATH
-  : FALLBACK_SEED_PATH;
+  : fs.existsSync(FALLBACK_SEED_PATH)
+    ? FALLBACK_SEED_PATH
+    : null;
 const PHOTOS_DIR = path.join(repoRoot, "photos-for-markers");
+const SUPPORTED_IMAGE_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "gif",
+  "heic",
+  "heif",
+  "bmp",
+  "tif",
+  "tiff",
+];
+const SUPPORTED_IMAGE_EXTENSION_PATTERN = new RegExp(
+  `\\.(${SUPPORTED_IMAGE_EXTENSIONS.join("|")})$`,
+  "iu",
+);
 const ADMIN_PROFILE_IMAGE_PATH = path.join(repoRoot, "assets/images/profile.png");
 const MAX_POLL_ATTEMPTS = 30;
 const POLL_DELAY_MS = 1000;
@@ -131,7 +149,11 @@ async function main() {
   const collectionId = config.collectionId || (await resolveCollectionId(databaseId));
 
   console.log(`Using Appwrite database ${databaseId} and collection ${collectionId}.`);
-  console.log(`Using seed file ${path.relative(repoRoot, SEED_PATH)}.`);
+  console.log(
+    SEED_PATH
+      ? `Using seed file ${path.relative(repoRoot, SEED_PATH)}.`
+      : "No marker seed file found; schema and storage sync will continue.",
+  );
 
   const collectionBefore = await getCollection(databaseId, collectionId);
   console.log("Updating collection security...");
@@ -150,6 +172,28 @@ async function main() {
   await ensureIndexes(databaseId, collectionId);
   console.log("Removing legacy duplicate marker attributes...");
   await cleanupLegacyAttributes(databaseId, collectionId);
+
+  if (!SEED_PATH) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          databaseId,
+          collectionId,
+          bucketId: config.bucketId,
+          seeded: {
+            total: 0,
+            created: 0,
+            skipped: 0,
+            photoAttachments: 0,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
 
   console.log("Resolving admin seed owner...");
   const adminUser = await resolveAdminUser();
@@ -294,7 +338,7 @@ async function updateBucketSecurity() {
       name: bucket.name,
       enabled: bucket.enabled,
       maximumFileSize: bucket.maximumFileSize,
-      allowedFileExtensions: bucket.allowedFileExtensions,
+      allowedFileExtensions: mergeAllowedFileExtensions(bucket.allowedFileExtensions),
       compression: bucket.compression,
       encryption: bucket.encryption,
       antivirus: bucket.antivirus,
@@ -471,7 +515,7 @@ function loadPhotoMatches() {
 
   const files = fs
     .readdirSync(PHOTOS_DIR)
-    .filter((fileName) => /\.(png|jpe?g|webp)$/iu.test(fileName))
+    .filter((fileName) => SUPPORTED_IMAGE_EXTENSION_PATTERN.test(fileName))
     .sort((left, right) => left.localeCompare(right));
   const photoMatches = new Map();
 
@@ -618,15 +662,33 @@ function formatLocation(latitude, longitude) {
 function getMimeType(filePath) {
   const extension = path.extname(filePath).toLowerCase();
 
-  if (extension === ".png") {
-    return "image/png";
+  switch (extension) {
+    case ".png":
+      return "image/png";
+    case ".webp":
+      return "image/webp";
+    case ".gif":
+      return "image/gif";
+    case ".heic":
+      return "image/heic";
+    case ".heif":
+      return "image/heif";
+    case ".bmp":
+      return "image/bmp";
+    case ".tif":
+    case ".tiff":
+      return "image/tiff";
+    default:
+      return "image/jpeg";
   }
+}
 
-  if (extension === ".webp") {
-    return "image/webp";
-  }
+function mergeAllowedFileExtensions(existingExtensions) {
+  const existing = Array.isArray(existingExtensions)
+    ? existingExtensions.map((extension) => String(extension).toLowerCase())
+    : [];
 
-  return "image/jpeg";
+  return Array.from(new Set([...existing, ...SUPPORTED_IMAGE_EXTENSIONS]));
 }
 
 function isDuplicateLocationError(error) {

--- a/src/features/map/components/InfoWindow.tsx
+++ b/src/features/map/components/InfoWindow.tsx
@@ -1,13 +1,5 @@
 import React, { useEffect, useState } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  Image,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
+import { FlatList, Image, Pressable, ScrollView, Text, View } from "react-native";
 
 import type { MarkerData } from "../core";
 import { MarkerWeatherCard, useMarkerWeather } from "@/features/weather";
@@ -34,8 +26,8 @@ const MarkerGalleryImageCard: React.FC<{
         onLoadEnd={() => setIsLoading(false)}
       />
       {isLoading ? (
-        <View className="absolute inset-0 items-center justify-center bg-slate-200/80">
-          <ActivityIndicator size="small" color="#475569" />
+        <View className="absolute inset-0 bg-slate-200">
+          <View className="h-full w-full bg-slate-300/70" />
         </View>
       ) : null}
     </Pressable>
@@ -62,7 +54,7 @@ const MarkerPreviewHero: React.FC<{
   }
 
   return (
-    <>
+    <View className="relative h-full w-full">
       <Image
         source={{ uri: photo }}
         resizeMode="cover"
@@ -71,11 +63,11 @@ const MarkerPreviewHero: React.FC<{
         onLoadEnd={() => setIsLoading(false)}
       />
       {isLoading ? (
-        <View className="absolute inset-0 items-center justify-center bg-slate-200/80">
-          <ActivityIndicator size="small" color="#475569" />
+        <View className="absolute inset-0 bg-slate-200">
+          <View className="h-full w-full bg-slate-300/70" />
         </View>
       ) : null}
-    </>
+    </View>
   );
 };
 
@@ -91,6 +83,7 @@ const InfoWindow: React.FC<InfoWindowProps> = ({
   onStartNavigation,
 }) => {
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const weather = useMarkerWeather(selectedMarker);
   const previewPhotos = selectedMarker?.photoUrls?.length
     ? selectedMarker.photoUrls
@@ -100,6 +93,7 @@ const InfoWindow: React.FC<InfoWindowProps> = ({
 
   useEffect(() => {
     setLightboxIndex(null);
+    setIsDescriptionExpanded(false);
   }, [selectedMarker?.id]);
 
   return (
@@ -125,12 +119,27 @@ const InfoWindow: React.FC<InfoWindowProps> = ({
                 <Text className="font-psemibold text-xl leading-7 text-slate-950">
                   {selectedMarker?.title ?? ""}
                 </Text>
-                <Text
-                  className="mt-2 font-pregular text-sm leading-6 text-slate-600"
-                  numberOfLines={2}
+                <Pressable
+                  onPress={() => setIsDescriptionExpanded((current) => !current)}
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    isDescriptionExpanded
+                      ? "Collapse marker description"
+                      : "Expand marker description"
+                  }
                 >
-                  {selectedMarker?.description ?? ""}
-                </Text>
+                  <Text
+                    className="mt-2 font-pregular text-sm leading-6 text-slate-600"
+                    numberOfLines={isDescriptionExpanded ? undefined : 2}
+                  >
+                    {selectedMarker?.description ?? ""}
+                  </Text>
+                  {selectedMarker?.description ? (
+                    <Text className="mt-1 font-psemibold text-xs text-slate-500">
+                      {isDescriptionExpanded ? "Show less" : "Show more"}
+                    </Text>
+                  ) : null}
+                </Pressable>
               </View>
             </View>
 

--- a/src/features/map/components/InfoWindow.tsx
+++ b/src/features/map/components/InfoWindow.tsx
@@ -3,7 +3,12 @@ import { FlatList, Image, Pressable, ScrollView, Text, View } from "react-native
 
 import type { MarkerData } from "../core";
 import { MarkerWeatherCard, useMarkerWeather } from "@/features/weather";
-import { BottomSheet, CustomButton, PhotoLightbox } from "@/shared/components";
+import {
+  BottomSheet,
+  CustomButton,
+  ImageLoadingPlaceholder,
+  PhotoLightbox,
+} from "@/shared/components";
 
 const COLLAPSED_HEIGHT = 292;
 
@@ -25,11 +30,7 @@ const MarkerGalleryImageCard: React.FC<{
         onLoadStart={() => setIsLoading(true)}
         onLoadEnd={() => setIsLoading(false)}
       />
-      {isLoading ? (
-        <View className="absolute inset-0 bg-slate-200">
-          <View className="h-full w-full bg-slate-300/70" />
-        </View>
-      ) : null}
+      {isLoading ? <ImageLoadingPlaceholder fill /> : null}
     </Pressable>
   );
 };
@@ -62,11 +63,7 @@ const MarkerPreviewHero: React.FC<{
         onLoadStart={() => setIsLoading(true)}
         onLoadEnd={() => setIsLoading(false)}
       />
-      {isLoading ? (
-        <View className="absolute inset-0 bg-slate-200">
-          <View className="h-full w-full bg-slate-300/70" />
-        </View>
-      ) : null}
+      {isLoading ? <ImageLoadingPlaceholder fill /> : null}
     </View>
   );
 };

--- a/src/features/map/components/InfoWindow.tsx
+++ b/src/features/map/components/InfoWindow.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 
 import type { MarkerData } from "../core";
+import { MarkerWeatherCard, useMarkerWeather } from "@/features/weather";
 import { BottomSheet, CustomButton, PhotoLightbox } from "@/shared/components";
 
 const COLLAPSED_HEIGHT = 292;
@@ -90,6 +91,7 @@ const InfoWindow: React.FC<InfoWindowProps> = ({
   onStartNavigation,
 }) => {
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const weather = useMarkerWeather(selectedMarker);
   const previewPhotos = selectedMarker?.photoUrls?.length
     ? selectedMarker.photoUrls
     : selectedMarker?.photoUrl
@@ -131,6 +133,15 @@ const InfoWindow: React.FC<InfoWindowProps> = ({
                 </Text>
               </View>
             </View>
+
+            <MarkerWeatherCard
+              markerId={selectedMarker?.id}
+              snapshot={weather.snapshot}
+              isLoading={weather.isLoading}
+              errorMessage={weather.errorMessage}
+              noticeMessage={weather.noticeMessage}
+              changeMessage={weather.changeMessage}
+            />
           </View>
         }
         bodyStyle={{ minHeight: 0 }}

--- a/src/features/map/components/__tests__/InfoWindow.test.tsx
+++ b/src/features/map/components/__tests__/InfoWindow.test.tsx
@@ -50,6 +50,7 @@ jest.mock("@/shared/components", () => {
         <Text>{title}</Text>
       </TouchableOpacity>
     ),
+    ImageLoadingPlaceholder: () => <View testID="image-loading-placeholder" />,
     PhotoLightbox: () => null,
   };
 });

--- a/src/features/map/components/__tests__/InfoWindow.test.tsx
+++ b/src/features/map/components/__tests__/InfoWindow.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { MarkerData } from "../../core";
+import InfoWindow from "../InfoWindow";
+
+jest.mock("@/features/weather", () => {
+  const { Text } = require("react-native");
+
+  return {
+    MarkerWeatherCard: () => <Text>Weather card</Text>,
+    useMarkerWeather: () => ({
+      snapshot: null,
+      isLoading: false,
+      errorMessage: null,
+      noticeMessage: null,
+      changeMessage: null,
+    }),
+  };
+});
+
+jest.mock("@/shared/components", () => {
+  const React = require("react");
+  const { Text, TouchableOpacity, View } = require("react-native");
+
+  return {
+    BottomSheet: ({
+      visible,
+      header,
+      children,
+    }: {
+      visible: boolean;
+      header: React.ReactNode;
+      children: React.ReactNode;
+    }) =>
+      visible ? (
+        <View>
+          {header}
+          {children}
+        </View>
+      ) : null,
+    CustomButton: ({
+      title,
+      handlePress,
+    }: {
+      title: string;
+      handlePress: () => void;
+    }) => (
+      <TouchableOpacity onPress={handlePress}>
+        <Text>{title}</Text>
+      </TouchableOpacity>
+    ),
+    PhotoLightbox: () => null,
+  };
+});
+
+const marker: MarkerData = {
+  id: "marker-1",
+  title: "Bench near Cathedral",
+  description:
+    "A longer marker description with useful details about shade, nearby noise, and why this sitting spot is worth checking before starting navigation.",
+  coordinate: {
+    latitude: 54.6872,
+    longitude: 25.2797,
+  },
+  location: "54.687200,25.279700",
+  status: "approved",
+  authorId: "admin-user",
+  createdAt: "2026-05-11T09:00:00.000Z",
+  photoUrl: "https://example.com/photo.jpg",
+  photoUrls: ["https://example.com/photo.jpg"],
+};
+
+describe("InfoWindow", () => {
+  it("expands and collapses the header description", () => {
+    const { getByLabelText, getAllByText } = render(
+      <InfoWindow selectedMarker={marker} />,
+    );
+    const [headerDescription] = getAllByText(marker.description);
+
+    expect(headerDescription.props.numberOfLines).toBe(2);
+
+    fireEvent.press(getByLabelText("Expand marker description"));
+
+    expect(getAllByText(marker.description)[0].props.numberOfLines).toBeUndefined();
+
+    fireEvent.press(getByLabelText("Collapse marker description"));
+
+    expect(getAllByText(marker.description)[0].props.numberOfLines).toBe(2);
+  });
+});

--- a/src/features/profile/ProfileScreen.tsx
+++ b/src/features/profile/ProfileScreen.tsx
@@ -14,6 +14,7 @@ import * as ImagePicker from "expo-image-picker";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useAuthContext } from "@/features/auth";
+import { useMarkerContext } from "@/features/map";
 import { MarkerGalleryTile } from "@/features/markers";
 import {
   signOut,
@@ -85,6 +86,7 @@ const MarkerGallerySkeleton: React.FC = () => (
 
 const ProfileScreen: React.FC = () => {
   const { user, setUser, setIsLogged, loading, setLoading } = useAuthContext();
+  const { setIsPlacementActive } = useMarkerContext();
   const router = useRouter();
   const [highlightedMarkerId, setHighlightedMarkerId] = useState<string | null>(null);
   const [markerBeingEdited, setMarkerBeingEdited] = useState<MarkerRecord | null>(null);
@@ -127,6 +129,18 @@ const ProfileScreen: React.FC = () => {
     setHighlightedMarkerId(null);
     markersListRef.current?.scrollToOffset({ offset: 0, animated: true });
   }, [currentPage]);
+
+  useEffect(() => {
+    const isEditingMarker = markerBeingEdited !== null;
+
+    setIsPlacementActive(isEditingMarker);
+
+    return () => {
+      if (isEditingMarker) {
+        setIsPlacementActive(false);
+      }
+    };
+  }, [markerBeingEdited, setIsPlacementActive]);
 
   const handleSignOut = async () => {
     setLoading(true);

--- a/src/features/profile/ProfileScreen.tsx
+++ b/src/features/profile/ProfileScreen.tsx
@@ -63,24 +63,9 @@ const getProfileInitials = (value?: string) =>
 const PROFILE_CARD_HEIGHT = 188;
 const PROFILE_CARD_GAP = 14;
 
-const MarkerGallerySkeleton: React.FC = () => (
-  <View className="flex-row flex-wrap justify-between gap-y-4 pt-2">
-    {Array.from({ length: 6 }).map((_, index) => (
-      <View
-        key={`marker-skeleton-${index}`}
-        className="overflow-hidden rounded-[24px] border border-slate-700 bg-slate-800"
-        style={{
-          width: "48%",
-          height: PROFILE_CARD_HEIGHT,
-        }}
-      >
-        <View className="h-[128px] bg-slate-700" />
-        <View className="px-3 py-3">
-          <View className="h-4 rounded-full bg-slate-600" />
-          <View className="mt-2 h-3 w-20 rounded-full bg-slate-700" />
-        </View>
-      </View>
-    ))}
+const MarkerGalleryLoadingState: React.FC = () => (
+  <View className="items-center justify-center rounded-[24px] bg-slate-800 py-12">
+    <ActivityIndicator color="#CBD5E1" size="small" />
   </View>
 );
 
@@ -297,7 +282,7 @@ const ProfileScreen: React.FC = () => {
         ListEmptyComponent={() => (
           <View className="py-6">
             {markersLoading ? (
-              <MarkerGallerySkeleton />
+              <MarkerGalleryLoadingState />
             ) : (
               <EmptyState
                 title="No submitted markers yet"

--- a/src/features/profile/__tests__/ProfileScreen.test.tsx
+++ b/src/features/profile/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { MarkerRecord } from "@/services/appwrite";
+import ProfileScreen from "../ProfileScreen";
+
+const mockReplace = jest.fn();
+const mockSetIsPlacementActive = jest.fn();
+const mockRefetchMarkers = jest.fn();
+
+const marker: MarkerRecord = {
+  id: "marker-1",
+  title: "Bench near Cathedral",
+  description: "Quiet spot",
+  coordinate: {
+    latitude: 54.6872,
+    longitude: 25.2797,
+  },
+  location: "54.687200,25.279700",
+  status: "approved",
+  authorId: "user-1",
+  createdAt: "2026-05-11T09:00:00.000Z",
+  photoUrl: null,
+  photoUrls: [],
+};
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}));
+
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  UIImagePickerPresentationStyle: {
+    FULL_SCREEN: "fullScreen",
+  },
+}));
+
+jest.mock("react-native-safe-area-context", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+jest.mock("@/features/auth", () => ({
+  useAuthContext: () => ({
+    user: {
+      $id: "user-1",
+      username: "Tester",
+      email: "tester@example.com",
+    },
+    setUser: jest.fn(),
+    setIsLogged: jest.fn(),
+    loading: false,
+    setLoading: jest.fn(),
+  }),
+}));
+
+jest.mock("@/features/map", () => ({
+  useMarkerContext: () => ({
+    setIsPlacementActive: mockSetIsPlacementActive,
+  }),
+}));
+
+jest.mock("@/features/markers", () => {
+  const React = require("react");
+  const { Text, TouchableOpacity } = require("react-native");
+
+  return {
+    MarkerGalleryTile: ({
+      marker,
+      onEditPress,
+    }: {
+      marker: MarkerRecord;
+      onEditPress: () => void;
+    }) => (
+      <TouchableOpacity onPress={onEditPress}>
+        <Text>Edit {marker.title}</Text>
+      </TouchableOpacity>
+    ),
+  };
+});
+
+jest.mock("@/services/appwrite", () => ({
+  signOut: jest.fn(),
+  updateMarker: jest.fn(),
+}));
+
+jest.mock("../hooks/useProfileMarkersPagination", () => ({
+  __esModule: true,
+  default: () => ({
+    markers: [marker],
+    currentPage: 1,
+    totalPages: 1,
+    totalCount: 1,
+    isLoading: false,
+    isRefreshing: false,
+    goToPage: jest.fn(),
+    refetch: mockRefetchMarkers,
+  }),
+}));
+
+jest.mock("../components/MarkerEditSheet", () => {
+  const React = require("react");
+  const { Text, TouchableOpacity, View } = require("react-native");
+
+  return function MockMarkerEditSheet({
+    marker,
+    onClose,
+  }: {
+    marker: MarkerRecord | null;
+    onClose: () => void;
+  }) {
+    return marker ? (
+      <View>
+        <Text>Editing {marker.title}</Text>
+        <TouchableOpacity onPress={onClose}>
+          <Text>Close editor</Text>
+        </TouchableOpacity>
+      </View>
+    ) : null;
+  };
+});
+
+describe("ProfileScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("hides the tab bar while the marker edit sheet is open", () => {
+    const { getByText, unmount } = render(<ProfileScreen />);
+
+    expect(mockSetIsPlacementActive).toHaveBeenLastCalledWith(false);
+
+    fireEvent.press(getByText("Edit Bench near Cathedral"));
+
+    expect(mockSetIsPlacementActive).toHaveBeenLastCalledWith(true);
+
+    fireEvent.press(getByText("Close editor"));
+
+    expect(mockSetIsPlacementActive).toHaveBeenLastCalledWith(false);
+
+    unmount();
+    expect(mockSetIsPlacementActive).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/features/weather/components/MarkerWeatherCard.tsx
+++ b/src/features/weather/components/MarkerWeatherCard.tsx
@@ -1,0 +1,195 @@
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import React, { useEffect, useState } from "react";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+
+import type { MarkerWeatherSnapshot, WeatherForecastHour } from "@/services/weather";
+
+import { getWeatherIconConfig } from "../utils/weatherIcons";
+
+type MarkerWeatherCardProps = {
+  snapshot: MarkerWeatherSnapshot | null;
+  isLoading: boolean;
+  errorMessage: string | null;
+  noticeMessage: string | null;
+  changeMessage: string | null;
+  markerId?: string | null;
+};
+
+const formatTemperature = (temperatureC: number | null) =>
+  temperatureC === null ? "--" : `${Math.round(temperatureC)}°C`;
+
+const formatForecastTime = (time: string) => {
+  const timePart = time.split("T")[1]?.slice(0, 5);
+
+  if (timePart) {
+    return timePart;
+  }
+
+  return time;
+};
+
+const formatRainChance = (probability: number | null) =>
+  probability === null ? null : `${Math.round(probability)}% rain`;
+
+const shouldShowFeelsLike = (temperatureC: number | null, feelsLikeC: number | null) =>
+  feelsLikeC !== null &&
+  (temperatureC === null ||
+    Math.abs(Math.round(temperatureC) - Math.round(feelsLikeC)) >= 1);
+
+const ForecastHourRow: React.FC<{ forecast: WeatherForecastHour }> = ({ forecast }) => {
+  const icon = getWeatherIconConfig(forecast.conditionLabel, forecast.conditionCode);
+
+  return (
+    <View className="mt-3 flex-row items-center justify-between">
+      <Text className="w-14 font-pmedium text-xs text-slate-500">
+        {formatForecastTime(forecast.time)}
+      </Text>
+      <View className="min-w-0 flex-1 flex-row items-center">
+        <View
+          className="h-6 w-6 items-center justify-center rounded-full"
+          style={{ backgroundColor: icon.backgroundColor }}
+        >
+          <MaterialCommunityIcons name={icon.name} size={16} color={icon.color} />
+        </View>
+        <Text className="ml-2 flex-1 font-pmedium text-xs text-slate-800">
+          {forecast.conditionLabel}
+        </Text>
+      </View>
+      <View className="items-end">
+        <Text className="font-psemibold text-xs text-slate-950">
+          {formatTemperature(forecast.temperatureC)}
+        </Text>
+        {shouldShowFeelsLike(forecast.temperatureC, forecast.feelsLikeC) ? (
+          <Text className="mt-0.5 font-pregular text-[11px] text-slate-500">
+            Feels {formatTemperature(forecast.feelsLikeC)}
+          </Text>
+        ) : formatRainChance(forecast.precipitationProbabilityPct) ? (
+          <Text className="mt-0.5 font-pregular text-[11px] text-slate-500">
+            {formatRainChance(forecast.precipitationProbabilityPct)}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+const MarkerWeatherCard: React.FC<MarkerWeatherCardProps> = ({
+  snapshot,
+  isLoading,
+  errorMessage,
+  noticeMessage,
+  changeMessage,
+  markerId,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const current = snapshot?.current ?? null;
+  const hasForecast = Boolean(snapshot && (current || snapshot.upcoming.length > 0));
+  const currentIcon = current
+    ? getWeatherIconConfig(current.conditionLabel, current.conditionCode)
+    : null;
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [markerId]);
+
+  return (
+    <Pressable
+      onPress={() => {
+        if (hasForecast) {
+          setIsExpanded((currentValue) => !currentValue);
+        }
+      }}
+      disabled={!hasForecast}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: isExpanded, disabled: !hasForecast }}
+      accessibilityLabel="Current weather"
+      className="mt-4 rounded-2xl border border-slate-200 bg-white px-4 py-3"
+    >
+      <View className="flex-row items-center justify-between">
+        {currentIcon ? (
+          <View
+            className="mr-3 h-11 w-11 items-center justify-center rounded-full"
+            style={{ backgroundColor: currentIcon.backgroundColor }}
+          >
+            <MaterialCommunityIcons
+              name={currentIcon.name}
+              size={24}
+              color={currentIcon.color}
+            />
+          </View>
+        ) : null}
+
+        <View className="min-w-0 flex-1">
+          <Text className="font-psemibold text-xs uppercase text-slate-500">
+            Current weather
+          </Text>
+          {current ? (
+            <>
+              <Text className="mt-1 font-psemibold text-sm text-slate-950">
+                {formatTemperature(current.temperatureC)} · {current.conditionLabel}
+              </Text>
+              {shouldShowFeelsLike(current.temperatureC, current.feelsLikeC) ? (
+                <Text className="mt-0.5 font-pregular text-xs text-slate-500">
+                  Feels like {formatTemperature(current.feelsLikeC)}
+                </Text>
+              ) : null}
+            </>
+          ) : errorMessage ? (
+            <Text className="mt-1 font-pregular text-sm leading-5 text-slate-600">
+              {errorMessage}
+            </Text>
+          ) : (
+            <Text className="mt-1 font-pregular text-sm text-slate-600">
+              Loading forecast...
+            </Text>
+          )}
+        </View>
+
+        {isLoading ? (
+          <ActivityIndicator size="small" color="#475569" />
+        ) : hasForecast ? (
+          <MaterialIcons
+            name={isExpanded ? "expand-less" : "expand-more"}
+            size={22}
+            color="#475569"
+          />
+        ) : null}
+      </View>
+
+      {noticeMessage ? (
+        <Text className="mt-2 font-pregular text-xs leading-5 text-amber-700">
+          {noticeMessage}
+        </Text>
+      ) : null}
+
+      {changeMessage ? (
+        <Text className="mt-2 font-pmedium text-xs leading-5 text-sky-700">
+          {changeMessage}
+        </Text>
+      ) : null}
+
+      {isExpanded && snapshot ? (
+        <View className="mt-3 border-t border-slate-100 pt-1">
+          <Text className="mt-2 font-psemibold text-xs uppercase text-slate-500">
+            Next 4 hours
+          </Text>
+          {snapshot.upcoming.length > 0 ? (
+            snapshot.upcoming.map((forecast) => (
+              <ForecastHourRow key={forecast.time} forecast={forecast} />
+            ))
+          ) : (
+            <Text className="mt-3 font-pregular text-xs text-slate-500">
+              Hourly forecast is unavailable.
+            </Text>
+          )}
+          <Text className="mt-3 font-pregular text-[11px] text-slate-400">
+            Weather by Open-Meteo
+          </Text>
+        </View>
+      ) : null}
+    </Pressable>
+  );
+};
+
+export default MarkerWeatherCard;

--- a/src/features/weather/components/__tests__/MarkerWeatherCard.test.tsx
+++ b/src/features/weather/components/__tests__/MarkerWeatherCard.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { MarkerWeatherSnapshot } from "@/services/weather";
+
+import MarkerWeatherCard from "../MarkerWeatherCard";
+
+jest.mock("@expo/vector-icons/MaterialIcons", () => {
+  const { Text } = require("react-native");
+  const MockMaterialIcons = ({ name }: { name: string }) => <Text>{name}</Text>;
+
+  MockMaterialIcons.displayName = "MockMaterialIcons";
+
+  return MockMaterialIcons;
+});
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const { Text } = require("react-native");
+  const MockMaterialCommunityIcons = ({ name }: { name: string }) => <Text>{name}</Text>;
+
+  MockMaterialCommunityIcons.displayName = "MockMaterialCommunityIcons";
+
+  return MockMaterialCommunityIcons;
+});
+
+const snapshot: MarkerWeatherSnapshot = {
+  provider: "open-meteo",
+  sourceLocationLabel: "Bench near Cathedral",
+  fetchedAt: "2026-05-01T09:00:00.000Z",
+  current: {
+    time: "2026-05-01T12:00",
+    temperatureC: 14.4,
+    feelsLikeC: 12.8,
+    precipitationMm: 0,
+    precipitationProbabilityPct: 20,
+    windSpeedKmh: 12,
+    humidityPct: 70,
+    cloudCoverPct: 80,
+    conditionCode: 61,
+    conditionLabel: "Rain",
+  },
+  upcoming: [
+    {
+      time: "2026-05-01T13:00",
+      temperatureC: 15,
+      feelsLikeC: 13,
+      precipitationMm: 0.1,
+      precipitationProbabilityPct: 25,
+      conditionCode: 61,
+      conditionLabel: "Rain",
+    },
+    {
+      time: "2026-05-02T00:00",
+      temperatureC: 16,
+      feelsLikeC: 15,
+      precipitationMm: 0,
+      precipitationProbabilityPct: 10,
+      conditionCode: 2,
+      conditionLabel: "Partly cloudy",
+    },
+  ],
+};
+
+describe("MarkerWeatherCard", () => {
+  it("renders compact current weather by default", () => {
+    const { getByText, queryByText } = render(
+      <MarkerWeatherCard
+        markerId="marker-1"
+        snapshot={snapshot}
+        isLoading={false}
+        errorMessage={null}
+        noticeMessage={null}
+        changeMessage={null}
+      />,
+    );
+
+    expect(getByText("Current weather")).toBeTruthy();
+    expect(getByText("14°C · Rain")).toBeTruthy();
+    expect(getByText("Feels like 13°C")).toBeTruthy();
+    expect(getByText("weather-pouring")).toBeTruthy();
+    expect(queryByText("Next 4 hours")).toBeNull();
+  });
+
+  it("expands to show the upcoming hourly forecast", () => {
+    const { getByLabelText, getByText } = render(
+      <MarkerWeatherCard
+        markerId="marker-1"
+        snapshot={snapshot}
+        isLoading={false}
+        errorMessage={null}
+        noticeMessage={null}
+        changeMessage={null}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Current weather"));
+
+    expect(getByText("Next 4 hours")).toBeTruthy();
+    expect(getByText("Partly cloudy")).toBeTruthy();
+    expect(getByText("weather-partly-cloudy")).toBeTruthy();
+    expect(getByText("00:00")).toBeTruthy();
+    expect(getByText("Feels 13°C")).toBeTruthy();
+    expect(getByText("Weather by Open-Meteo")).toBeTruthy();
+  });
+
+  it("renders unavailable and stale messages", () => {
+    const { getByText, rerender } = render(
+      <MarkerWeatherCard
+        markerId="marker-1"
+        snapshot={null}
+        isLoading={false}
+        errorMessage="Weather forecast is temporarily unavailable"
+        noticeMessage={null}
+        changeMessage={null}
+      />,
+    );
+
+    expect(getByText("Weather forecast is temporarily unavailable")).toBeTruthy();
+
+    rerender(
+      <MarkerWeatherCard
+        markerId="marker-1"
+        snapshot={snapshot}
+        isLoading={false}
+        errorMessage={null}
+        noticeMessage="Weather forecast updated 2 hours ago."
+        changeMessage={null}
+      />,
+    );
+
+    expect(getByText("Weather forecast updated 2 hours ago.")).toBeTruthy();
+  });
+
+  it("renders weather change messages", () => {
+    const { getByText } = render(
+      <MarkerWeatherCard
+        markerId="marker-1"
+        snapshot={snapshot}
+        isLoading={false}
+        errorMessage={null}
+        noticeMessage={null}
+        changeMessage="Weather change expected: 65% rain chance in the next hour."
+      />,
+    );
+
+    expect(
+      getByText("Weather change expected: 65% rain chance in the next hour."),
+    ).toBeTruthy();
+  });
+});

--- a/src/features/weather/hooks/__tests__/useMarkerWeather.test.tsx
+++ b/src/features/weather/hooks/__tests__/useMarkerWeather.test.tsx
@@ -1,0 +1,142 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+import {
+  fetchOpenMeteoWeatherSnapshot,
+  type MarkerWeatherSnapshot,
+} from "@/services/weather";
+
+import useMarkerWeather, { WEATHER_UNAVAILABLE_MESSAGE } from "../useMarkerWeather";
+import { clearWeatherCache, setWeatherCacheEntry } from "../../utils/weatherCache";
+
+jest.mock("@/services/weather", () => ({
+  fetchOpenMeteoWeatherSnapshot: jest.fn(),
+}));
+
+jest.mock("../../utils/weatherTestScenarios", () => ({
+  getWeatherTestScenarioResult: jest.fn(() => null),
+}));
+
+const mockedFetchWeather = jest.mocked(fetchOpenMeteoWeatherSnapshot);
+
+const marker = {
+  id: "marker-1",
+  title: "Bench near Cathedral",
+  coordinate: { latitude: 54.6872, longitude: 25.2797 },
+};
+
+const createSnapshot = (
+  overrides?: Partial<MarkerWeatherSnapshot>,
+): MarkerWeatherSnapshot => ({
+  provider: "open-meteo",
+  sourceLocationLabel: "Bench near Cathedral",
+  fetchedAt: "2026-05-01T09:00:00.000Z",
+  current: {
+    time: "2026-05-01T12:00",
+    temperatureC: 14,
+    feelsLikeC: 13,
+    precipitationMm: 0,
+    precipitationProbabilityPct: 20,
+    windSpeedKmh: 12,
+    humidityPct: 70,
+    cloudCoverPct: 80,
+    conditionCode: 61,
+    conditionLabel: "Rain",
+  },
+  upcoming: [],
+  ...overrides,
+});
+
+describe("useMarkerWeather", () => {
+  beforeEach(() => {
+    clearWeatherCache();
+    jest.clearAllMocks();
+  });
+
+  it("fetches weather for a selected marker", async () => {
+    const snapshot = createSnapshot();
+    mockedFetchWeather.mockResolvedValueOnce(snapshot);
+
+    const { result } = renderHook(() => useMarkerWeather(marker));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.snapshot).toBe(snapshot));
+
+    expect(mockedFetchWeather).toHaveBeenCalledWith({
+      coordinate: marker.coordinate,
+      sourceLocationLabel: marker.title,
+      upcomingHours: 4,
+    });
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.changeMessage).toBeNull();
+  });
+
+  it("detects next-hour weather changes", async () => {
+    const snapshot = createSnapshot({
+      upcoming: [
+        {
+          time: "2026-05-01T13:00",
+          temperatureC: 16,
+          feelsLikeC: 14,
+          precipitationMm: 1,
+          precipitationProbabilityPct: 65,
+          conditionCode: 61,
+          conditionLabel: "Rain",
+        },
+      ],
+    });
+    mockedFetchWeather.mockResolvedValueOnce(snapshot);
+
+    const { result } = renderHook(() => useMarkerWeather(marker));
+
+    await waitFor(() =>
+      expect(result.current.changeMessage).toBe(
+        "Weather change expected: 65% rain chance in the next hour.",
+      ),
+    );
+  });
+
+  it("uses fresh cached weather without fetching again", async () => {
+    const snapshot = createSnapshot();
+    setWeatherCacheEntry("marker:marker-1", snapshot);
+
+    const { result } = renderHook(() => useMarkerWeather(marker));
+
+    await waitFor(() => expect(result.current.snapshot).toBe(snapshot));
+
+    expect(mockedFetchWeather).not.toHaveBeenCalled();
+  });
+
+  it("falls back to stale cached weather when refresh fails", async () => {
+    const snapshot = createSnapshot({
+      fetchedAt: "2026-05-01T09:00:00.000Z",
+    });
+    const now = Date.parse("2026-05-01T11:15:00.000Z");
+
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    setWeatherCacheEntry("marker:marker-1", snapshot, now - 31 * 60 * 1000);
+    mockedFetchWeather.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useMarkerWeather(marker));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.snapshot).toBe(snapshot);
+    expect(result.current.noticeMessage).toBe("Weather forecast updated 2 hours ago.");
+    expect(result.current.errorMessage).toBeNull();
+
+    jest.restoreAllMocks();
+  });
+
+  it("shows an unavailable message when weather cannot be fetched and no cache exists", async () => {
+    mockedFetchWeather.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useMarkerWeather(marker));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.snapshot).toBeNull();
+    expect(result.current.errorMessage).toBe(WEATHER_UNAVAILABLE_MESSAGE);
+    expect(result.current.changeMessage).toBeNull();
+  });
+});

--- a/src/features/weather/hooks/useMarkerWeather.ts
+++ b/src/features/weather/hooks/useMarkerWeather.ts
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  fetchOpenMeteoWeatherSnapshot,
+  type MarkerWeatherSnapshot,
+  type WeatherCoordinate,
+} from "@/services/weather";
+
+import {
+  getStaleWeatherNotice,
+  getWeatherCacheEntry,
+  getWeatherCacheKey,
+  isWeatherCacheFresh,
+  setWeatherCacheEntry,
+} from "../utils/weatherCache";
+import { getWeatherChangeMessage } from "../utils/weatherChanges";
+import { getWeatherTestScenarioResult } from "../utils/weatherTestScenarios";
+
+const UPCOMING_FORECAST_HOURS = 4;
+
+export type WeatherMarkerInput = {
+  id?: string | null;
+  title?: string | null;
+  coordinate: WeatherCoordinate;
+};
+
+export type MarkerWeatherState = {
+  snapshot: MarkerWeatherSnapshot | null;
+  isLoading: boolean;
+  errorMessage: string | null;
+  noticeMessage: string | null;
+  changeMessage: string | null;
+};
+
+const WEATHER_UNAVAILABLE_MESSAGE = "Weather forecast is temporarily unavailable";
+
+const EMPTY_WEATHER_STATE: MarkerWeatherState = {
+  snapshot: null,
+  isLoading: false,
+  errorMessage: null,
+  noticeMessage: null,
+  changeMessage: null,
+};
+
+const buildStateFromSnapshot = (
+  snapshot: MarkerWeatherSnapshot,
+  nowMs = Date.now(),
+): MarkerWeatherState => ({
+  snapshot,
+  isLoading: false,
+  errorMessage: null,
+  noticeMessage: getStaleWeatherNotice(snapshot, nowMs),
+  changeMessage: getWeatherChangeMessage(snapshot),
+});
+
+const isWeatherMarkerInput = (
+  marker: WeatherMarkerInput | null,
+): marker is WeatherMarkerInput =>
+  Boolean(
+    marker &&
+    Number.isFinite(marker.coordinate.latitude) &&
+    Number.isFinite(marker.coordinate.longitude),
+  );
+
+const useMarkerWeather = (marker: WeatherMarkerInput | null): MarkerWeatherState => {
+  const cacheKey = useMemo(
+    () =>
+      isWeatherMarkerInput(marker)
+        ? getWeatherCacheKey(marker.id, marker.coordinate)
+        : null,
+    [marker],
+  );
+
+  const [state, setState] = useState<MarkerWeatherState>(EMPTY_WEATHER_STATE);
+
+  useEffect(() => {
+    if (!cacheKey || !isWeatherMarkerInput(marker)) {
+      setState(EMPTY_WEATHER_STATE);
+      return;
+    }
+
+    let isActive = true;
+    const cachedEntry = getWeatherCacheEntry(cacheKey);
+    const testScenario = getWeatherTestScenarioResult(marker.title ?? "Selected marker");
+
+    if (testScenario?.type === "unavailable") {
+      setState({
+        snapshot: null,
+        isLoading: false,
+        errorMessage: WEATHER_UNAVAILABLE_MESSAGE,
+        noticeMessage: null,
+        changeMessage: null,
+      });
+      return;
+    }
+
+    if (testScenario?.type === "snapshot") {
+      setState(buildStateFromSnapshot(testScenario.snapshot));
+      return;
+    }
+
+    if (cachedEntry && isWeatherCacheFresh(cachedEntry)) {
+      setState(buildStateFromSnapshot(cachedEntry.snapshot));
+      return;
+    }
+
+    setState((current) => ({
+      snapshot: cachedEntry?.snapshot ?? current.snapshot,
+      isLoading: true,
+      errorMessage: null,
+      noticeMessage: cachedEntry
+        ? getStaleWeatherNotice(cachedEntry.snapshot)
+        : current.noticeMessage,
+      changeMessage: cachedEntry
+        ? getWeatherChangeMessage(cachedEntry.snapshot)
+        : current.changeMessage,
+    }));
+
+    fetchOpenMeteoWeatherSnapshot({
+      coordinate: marker.coordinate,
+      sourceLocationLabel: marker.title ?? "Selected marker",
+      upcomingHours: UPCOMING_FORECAST_HOURS,
+    })
+      .then((snapshot) => {
+        if (!isActive) {
+          return;
+        }
+
+        setWeatherCacheEntry(cacheKey, snapshot);
+        setState(buildStateFromSnapshot(snapshot));
+      })
+      .catch(() => {
+        if (!isActive) {
+          return;
+        }
+
+        if (cachedEntry) {
+          setState(buildStateFromSnapshot(cachedEntry.snapshot));
+          return;
+        }
+
+        setState({
+          snapshot: null,
+          isLoading: false,
+          errorMessage: WEATHER_UNAVAILABLE_MESSAGE,
+          noticeMessage: null,
+          changeMessage: null,
+        });
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [cacheKey, marker]);
+
+  return state;
+};
+
+export { UPCOMING_FORECAST_HOURS, WEATHER_UNAVAILABLE_MESSAGE };
+export default useMarkerWeather;

--- a/src/features/weather/index.ts
+++ b/src/features/weather/index.ts
@@ -1,0 +1,6 @@
+export { default as MarkerWeatherCard } from "./components/MarkerWeatherCard";
+export {
+  default as useMarkerWeather,
+  UPCOMING_FORECAST_HOURS,
+  WEATHER_UNAVAILABLE_MESSAGE,
+} from "./hooks/useMarkerWeather";

--- a/src/features/weather/utils/__tests__/weatherCache.test.ts
+++ b/src/features/weather/utils/__tests__/weatherCache.test.ts
@@ -1,0 +1,66 @@
+import type { MarkerWeatherSnapshot } from "@/services/weather";
+
+import {
+  clearWeatherCache,
+  getStaleWeatherNotice,
+  getWeatherCacheEntry,
+  getWeatherCacheKey,
+  isWeatherCacheFresh,
+  setWeatherCacheEntry,
+  WEATHER_CACHE_TTL_MS,
+} from "../weatherCache";
+
+const createSnapshot = (fetchedAt: string): MarkerWeatherSnapshot => ({
+  provider: "open-meteo",
+  sourceLocationLabel: "Bench near Cathedral",
+  fetchedAt,
+  current: null,
+  upcoming: [],
+});
+
+describe("weather cache helpers", () => {
+  beforeEach(() => {
+    clearWeatherCache();
+  });
+
+  it("keys weather by marker id before falling back to a coordinate bucket", () => {
+    const coordinate = { latitude: 54.687234, longitude: 25.279745 };
+
+    expect(getWeatherCacheKey("marker-1", coordinate)).toBe("marker:marker-1");
+    expect(getWeatherCacheKey(null, coordinate)).toBe("coord:54.687,25.280");
+  });
+
+  it("stores and reads cached weather snapshots", () => {
+    const snapshot = createSnapshot("2026-05-01T09:00:00.000Z");
+
+    setWeatherCacheEntry("marker:marker-1", snapshot, 1000);
+
+    expect(getWeatherCacheEntry("marker:marker-1")).toEqual({
+      snapshot,
+      storedAtMs: 1000,
+    });
+  });
+
+  it("treats cache entries as fresh only inside the weather TTL", () => {
+    const snapshot = createSnapshot("2026-05-01T09:00:00.000Z");
+    const entry = { snapshot, storedAtMs: 1000 };
+
+    expect(isWeatherCacheFresh(entry, 1000 + WEATHER_CACHE_TTL_MS - 1)).toBe(true);
+    expect(isWeatherCacheFresh(entry, 1000 + WEATHER_CACHE_TTL_MS)).toBe(false);
+  });
+
+  it("builds stale notices only after at least one hour", () => {
+    expect(
+      getStaleWeatherNotice(
+        createSnapshot("2026-05-01T09:00:00.000Z"),
+        Date.parse("2026-05-01T09:59:00.000Z"),
+      ),
+    ).toBeNull();
+    expect(
+      getStaleWeatherNotice(
+        createSnapshot("2026-05-01T09:00:00.000Z"),
+        Date.parse("2026-05-01T11:15:00.000Z"),
+      ),
+    ).toBe("Weather forecast updated 2 hours ago.");
+  });
+});

--- a/src/features/weather/utils/__tests__/weatherChanges.test.ts
+++ b/src/features/weather/utils/__tests__/weatherChanges.test.ts
@@ -1,0 +1,139 @@
+import type { MarkerWeatherSnapshot } from "@/services/weather";
+
+import { getWeatherChangeMessage } from "../weatherChanges";
+
+const createSnapshot = (
+  overrides?: Partial<MarkerWeatherSnapshot>,
+): MarkerWeatherSnapshot => ({
+  provider: "open-meteo",
+  sourceLocationLabel: "Bench near Cathedral",
+  fetchedAt: "2026-05-01T09:00:00.000Z",
+  current: {
+    time: "2026-05-01T12:00",
+    temperatureC: 14,
+    feelsLikeC: 13,
+    precipitationMm: 0,
+    precipitationProbabilityPct: 20,
+    windSpeedKmh: 12,
+    humidityPct: 70,
+    cloudCoverPct: 80,
+    conditionCode: 1,
+    conditionLabel: "Mainly clear",
+  },
+  upcoming: [
+    {
+      time: "2026-05-01T13:00",
+      temperatureC: 16,
+      feelsLikeC: 14,
+      precipitationMm: 0,
+      precipitationProbabilityPct: 40,
+      conditionCode: 2,
+      conditionLabel: "Partly cloudy",
+    },
+  ],
+  ...overrides,
+});
+
+describe("weather change detection", () => {
+  it("does not report changes at or below thresholds", () => {
+    expect(
+      getWeatherChangeMessage(
+        createSnapshot({
+          upcoming: [
+            {
+              time: "2026-05-01T13:00",
+              temperatureC: 19,
+              feelsLikeC: 18,
+              precipitationMm: 0,
+              precipitationProbabilityPct: 50,
+              conditionCode: 2,
+              conditionLabel: "Partly cloudy",
+            },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("reports rain probability above 50 percent in the next hour", () => {
+    expect(
+      getWeatherChangeMessage(
+        createSnapshot({
+          upcoming: [
+            {
+              time: "2026-05-01T13:00",
+              temperatureC: 16,
+              feelsLikeC: 14,
+              precipitationMm: 1,
+              precipitationProbabilityPct: 65,
+              conditionCode: 61,
+              conditionLabel: "Rain",
+            },
+          ],
+        }),
+      ),
+    ).toBe("Weather change expected: 65% rain chance in the next hour.");
+  });
+
+  it("reports temperature shifts above 5 degrees in the next hour", () => {
+    expect(
+      getWeatherChangeMessage(
+        createSnapshot({
+          upcoming: [
+            {
+              time: "2026-05-01T13:00",
+              temperatureC: 7.8,
+              feelsLikeC: 5,
+              precipitationMm: 0,
+              precipitationProbabilityPct: 10,
+              conditionCode: 3,
+              conditionLabel: "Overcast",
+            },
+          ],
+        }),
+      ),
+    ).toBe("Weather change expected: temperature drops by 6°C in the next hour.");
+  });
+
+  it("reports temperature rises above 5 degrees in the next hour", () => {
+    expect(
+      getWeatherChangeMessage(
+        createSnapshot({
+          upcoming: [
+            {
+              time: "2026-05-01T13:00",
+              temperatureC: 20.2,
+              feelsLikeC: 19,
+              precipitationMm: 0,
+              precipitationProbabilityPct: 10,
+              conditionCode: 1,
+              conditionLabel: "Mainly clear",
+            },
+          ],
+        }),
+      ),
+    ).toBe("Weather change expected: temperature rises by 6°C in the next hour.");
+  });
+
+  it("combines rain and temperature change messages", () => {
+    expect(
+      getWeatherChangeMessage(
+        createSnapshot({
+          upcoming: [
+            {
+              time: "2026-05-01T13:00",
+              temperatureC: 20.4,
+              feelsLikeC: 19,
+              precipitationMm: 2,
+              precipitationProbabilityPct: 80,
+              conditionCode: 63,
+              conditionLabel: "Rain",
+            },
+          ],
+        }),
+      ),
+    ).toBe(
+      "Weather change expected: 80% rain chance and temperature rises by 6°C in the next hour.",
+    );
+  });
+});

--- a/src/features/weather/utils/__tests__/weatherIcons.test.ts
+++ b/src/features/weather/utils/__tests__/weatherIcons.test.ts
@@ -1,0 +1,36 @@
+import { getWeatherIconConfig } from "../weatherIcons";
+
+describe("weather icons", () => {
+  it("maps common conditions to Material icons", () => {
+    expect(getWeatherIconConfig("Clear", 0)).toEqual({
+      name: "weather-sunny",
+      color: "#D97706",
+      backgroundColor: "#FEF3C7",
+    });
+    expect(getWeatherIconConfig("Partly cloudy", 2)).toEqual({
+      name: "weather-partly-cloudy",
+      color: "#475569",
+      backgroundColor: "#E0F2FE",
+    });
+    expect(getWeatherIconConfig("Overcast", 3)).toEqual({
+      name: "weather-cloudy",
+      color: "#475569",
+      backgroundColor: "#E2E8F0",
+    });
+    expect(getWeatherIconConfig("Rain", 61)).toEqual({
+      name: "weather-pouring",
+      color: "#0369A1",
+      backgroundColor: "#DBEAFE",
+    });
+    expect(getWeatherIconConfig("Snow", 71)).toEqual({
+      name: "weather-snowy",
+      color: "#0284C7",
+      backgroundColor: "#E0F2FE",
+    });
+    expect(getWeatherIconConfig("Thunderstorm", 95)).toEqual({
+      name: "weather-lightning-rainy",
+      color: "#475569",
+      backgroundColor: "#E2E8F0",
+    });
+  });
+});

--- a/src/features/weather/utils/__tests__/weatherTestScenarios.test.ts
+++ b/src/features/weather/utils/__tests__/weatherTestScenarios.test.ts
@@ -1,0 +1,82 @@
+describe("weather test scenarios", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  const loadScenario = (scenario: string) => {
+    jest.doMock("expo-constants", () => ({
+      expoConfig: {
+        extra: {
+          WEATHER_TEST_SCENARIO: scenario,
+        },
+      },
+    }));
+
+    return require("../weatherTestScenarios") as typeof import("../weatherTestScenarios");
+  };
+
+  it("creates a dev rain scenario snapshot", () => {
+    const { getWeatherTestScenarioSnapshot } = loadScenario("rain");
+    const snapshot = getWeatherTestScenarioSnapshot("Bench near Cathedral");
+
+    expect(snapshot).toMatchObject({
+      provider: "open-meteo",
+      sourceLocationLabel: "Bench near Cathedral",
+      current: {
+        temperatureC: 14,
+      },
+      upcoming: expect.arrayContaining([
+        expect.objectContaining({
+          precipitationProbabilityPct: 65,
+          conditionLabel: "Rain",
+        }),
+      ]),
+    });
+  });
+
+  it("creates a dev temperature drop scenario snapshot", () => {
+    const { getWeatherTestScenarioSnapshot } = loadScenario("temperature-drop");
+    const snapshot = getWeatherTestScenarioSnapshot("Bench near Cathedral");
+
+    expect(snapshot?.current?.temperatureC).toBe(14);
+    expect(snapshot?.upcoming[0].temperatureC).toBe(7.5);
+    expect(snapshot?.upcoming[0].precipitationProbabilityPct).toBe(10);
+  });
+
+  it("creates a dev unavailable scenario result", () => {
+    const { getWeatherTestScenarioResult } = loadScenario("unavailable");
+
+    expect(getWeatherTestScenarioResult("Bench near Cathedral")).toEqual({
+      type: "unavailable",
+    });
+  });
+
+  it("creates a dev stale scenario snapshot", () => {
+    const now = Date.parse("2026-05-07T12:00:00.000Z");
+
+    jest.spyOn(Date, "now").mockReturnValue(now);
+
+    const { getWeatherTestScenarioSnapshot } = loadScenario("stale");
+    const snapshot = getWeatherTestScenarioSnapshot("Bench near Cathedral");
+
+    expect(snapshot?.fetchedAt).toBe("2026-05-07T10:00:00.000Z");
+
+    jest.restoreAllMocks();
+  });
+
+  it("creates a dev icon gallery scenario snapshot", () => {
+    const { getWeatherTestScenarioSnapshot } = loadScenario("icons");
+    const snapshot = getWeatherTestScenarioSnapshot("Bench near Cathedral");
+
+    expect(snapshot?.current?.conditionLabel).toBe("Clear");
+    expect(snapshot?.upcoming.map((forecast) => forecast.conditionLabel)).toEqual([
+      "Partly cloudy",
+      "Overcast",
+      "Rain",
+      "Snow",
+      "Thunderstorm",
+      "Fog",
+      "Unknown",
+    ]);
+  });
+});

--- a/src/features/weather/utils/weatherCache.ts
+++ b/src/features/weather/utils/weatherCache.ts
@@ -1,0 +1,68 @@
+import type { MarkerWeatherSnapshot, WeatherCoordinate } from "@/services/weather";
+
+const WEATHER_CACHE_TTL_MS = 30 * 60 * 1000;
+const STALE_WEATHER_NOTICE_MS = 60 * 60 * 1000;
+
+export type WeatherCacheEntry = {
+  snapshot: MarkerWeatherSnapshot;
+  storedAtMs: number;
+};
+
+const weatherCache = new Map<string, WeatherCacheEntry>();
+
+export const getWeatherCacheKey = (
+  markerId: string | null | undefined,
+  coordinate: WeatherCoordinate,
+) => {
+  if (markerId) {
+    return `marker:${markerId}`;
+  }
+
+  return `coord:${coordinate.latitude.toFixed(3)},${coordinate.longitude.toFixed(3)}`;
+};
+
+export const getWeatherCacheEntry = (cacheKey: string): WeatherCacheEntry | null =>
+  weatherCache.get(cacheKey) ?? null;
+
+export const setWeatherCacheEntry = (
+  cacheKey: string,
+  snapshot: MarkerWeatherSnapshot,
+  storedAtMs = Date.now(),
+) => {
+  weatherCache.set(cacheKey, { snapshot, storedAtMs });
+};
+
+export const clearWeatherCache = () => {
+  weatherCache.clear();
+};
+
+export const isWeatherCacheFresh = (entry: WeatherCacheEntry, nowMs = Date.now()) =>
+  nowMs - entry.storedAtMs < WEATHER_CACHE_TTL_MS;
+
+export const getWeatherSnapshotAgeHours = (
+  snapshot: MarkerWeatherSnapshot,
+  nowMs = Date.now(),
+) => {
+  const fetchedAtMs = Date.parse(snapshot.fetchedAt);
+
+  if (!Number.isFinite(fetchedAtMs)) {
+    return null;
+  }
+
+  return Math.max(0, Math.floor((nowMs - fetchedAtMs) / STALE_WEATHER_NOTICE_MS));
+};
+
+export const getStaleWeatherNotice = (
+  snapshot: MarkerWeatherSnapshot,
+  nowMs = Date.now(),
+) => {
+  const ageHours = getWeatherSnapshotAgeHours(snapshot, nowMs);
+
+  if (ageHours === null || ageHours < 1) {
+    return null;
+  }
+
+  return `Weather forecast updated ${ageHours} hours ago.`;
+};
+
+export { STALE_WEATHER_NOTICE_MS, WEATHER_CACHE_TTL_MS };

--- a/src/features/weather/utils/weatherChanges.ts
+++ b/src/features/weather/utils/weatherChanges.ts
@@ -1,0 +1,58 @@
+import type { MarkerWeatherSnapshot } from "@/services/weather";
+
+const RAIN_PROBABILITY_CHANGE_THRESHOLD = 50;
+const TEMPERATURE_CHANGE_THRESHOLD_C = 5;
+
+const formatTemperatureDelta = (deltaC: number) => `${Math.round(deltaC)}°C`;
+
+const getTemperatureChangeLabel = (
+  currentTemperatureC: number,
+  nextTemperatureC: number,
+) => (nextTemperatureC < currentTemperatureC ? "drops" : "rises");
+
+export const getWeatherChangeMessage = (
+  snapshot: MarkerWeatherSnapshot | null,
+): string | null => {
+  const current = snapshot?.current;
+  const nextHour = snapshot?.upcoming[0];
+
+  if (!current || !nextHour) {
+    return null;
+  }
+
+  const rainProbability = nextHour.precipitationProbabilityPct;
+  const temperatureDelta =
+    current.temperatureC === null || nextHour.temperatureC === null
+      ? null
+      : Math.abs(nextHour.temperatureC - current.temperatureC);
+  const hasRainChange =
+    rainProbability !== null && rainProbability > RAIN_PROBABILITY_CHANGE_THRESHOLD;
+  const hasTemperatureChange =
+    temperatureDelta !== null && temperatureDelta > TEMPERATURE_CHANGE_THRESHOLD_C;
+  const temperatureChangeLabel =
+    current.temperatureC !== null && nextHour.temperatureC !== null
+      ? getTemperatureChangeLabel(current.temperatureC, nextHour.temperatureC)
+      : "changes";
+
+  if (hasRainChange && hasTemperatureChange) {
+    return `Weather change expected: ${Math.round(
+      rainProbability,
+    )}% rain chance and temperature ${temperatureChangeLabel} by ${formatTemperatureDelta(
+      temperatureDelta,
+    )} in the next hour.`;
+  }
+
+  if (hasRainChange) {
+    return `Weather change expected: ${Math.round(
+      rainProbability,
+    )}% rain chance in the next hour.`;
+  }
+
+  if (hasTemperatureChange) {
+    return `Weather change expected: temperature ${temperatureChangeLabel} by ${formatTemperatureDelta(
+      temperatureDelta,
+    )} in the next hour.`;
+  }
+
+  return null;
+};

--- a/src/features/weather/utils/weatherIcons.ts
+++ b/src/features/weather/utils/weatherIcons.ts
@@ -1,0 +1,57 @@
+import type { ComponentProps } from "react";
+import type MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+
+import type { WeatherConditionCode } from "@/services/weather";
+
+type WeatherIconName = ComponentProps<typeof MaterialCommunityIcons>["name"];
+
+export type WeatherIconConfig = {
+  name: WeatherIconName;
+  color: string;
+  backgroundColor: string;
+};
+
+export const getWeatherIconConfig = (
+  conditionLabel: string,
+  conditionCode: WeatherConditionCode,
+): WeatherIconConfig => {
+  const label = conditionLabel.toLowerCase();
+
+  if (label.includes("thunderstorm")) {
+    return {
+      name: "weather-lightning-rainy",
+      color: "#475569",
+      backgroundColor: "#E2E8F0",
+    };
+  }
+
+  if (label.includes("snow") || conditionCode === 77) {
+    return { name: "weather-snowy", color: "#0284C7", backgroundColor: "#E0F2FE" };
+  }
+
+  if (label.includes("rain") || label.includes("drizzle")) {
+    return { name: "weather-pouring", color: "#0369A1", backgroundColor: "#DBEAFE" };
+  }
+
+  if (label.includes("fog")) {
+    return { name: "weather-fog", color: "#64748B", backgroundColor: "#F1F5F9" };
+  }
+
+  if (label.includes("partly cloudy")) {
+    return {
+      name: "weather-partly-cloudy",
+      color: "#475569",
+      backgroundColor: "#E0F2FE",
+    };
+  }
+
+  if (label.includes("overcast") || label.includes("cloudy")) {
+    return { name: "weather-cloudy", color: "#475569", backgroundColor: "#E2E8F0" };
+  }
+
+  if (label.includes("clear")) {
+    return { name: "weather-sunny", color: "#D97706", backgroundColor: "#FEF3C7" };
+  }
+
+  return { name: "thermometer", color: "#475569", backgroundColor: "#F1F5F9" };
+};

--- a/src/features/weather/utils/weatherTestScenarios.ts
+++ b/src/features/weather/utils/weatherTestScenarios.ts
@@ -1,0 +1,236 @@
+import Constants from "expo-constants";
+
+import type { MarkerWeatherSnapshot } from "@/services/weather";
+
+type ExpoExtra = Record<string, string | undefined>;
+type WeatherTestScenario =
+  | "rain"
+  | "temperature"
+  | "temperature-drop"
+  | "unavailable"
+  | "stale"
+  | "icons";
+
+type WeatherTestScenarioResult =
+  | { type: "snapshot"; snapshot: MarkerWeatherSnapshot }
+  | { type: "unavailable" };
+
+const constantsWithUntypedManifest = Constants as typeof Constants & {
+  manifest?: { extra?: ExpoExtra } | null;
+  manifest2?: { extra?: { expoClient?: { extra?: ExpoExtra } } } | null;
+};
+
+const expoExtra: ExpoExtra =
+  Constants.expoConfig?.extra ??
+  constantsWithUntypedManifest.manifest?.extra ??
+  constantsWithUntypedManifest.manifest2?.extra?.expoClient?.extra ??
+  {};
+
+const getEnabledScenario = (): WeatherTestScenario | null => {
+  if (!__DEV__) {
+    return null;
+  }
+
+  const scenario = expoExtra.WEATHER_TEST_SCENARIO;
+
+  return scenario === "rain" ||
+    scenario === "temperature" ||
+    scenario === "temperature-drop" ||
+    scenario === "unavailable" ||
+    scenario === "stale" ||
+    scenario === "icons"
+    ? scenario
+    : null;
+};
+
+const createBaseSnapshot = (sourceLocationLabel: string): MarkerWeatherSnapshot => {
+  const fetchedAt = new Date().toISOString();
+
+  return {
+    provider: "open-meteo",
+    sourceLocationLabel,
+    fetchedAt,
+    current: {
+      time: "2026-05-07T12:00",
+      temperatureC: 14,
+      feelsLikeC: 12,
+      precipitationMm: 0,
+      precipitationProbabilityPct: 20,
+      windSpeedKmh: 12,
+      humidityPct: 70,
+      cloudCoverPct: 80,
+      conditionCode: 3,
+      conditionLabel: "Overcast",
+    },
+    upcoming: [
+      {
+        time: "2026-05-07T13:00",
+        temperatureC: 15,
+        feelsLikeC: 13,
+        precipitationMm: 1.2,
+        precipitationProbabilityPct: 65,
+        conditionCode: 61,
+        conditionLabel: "Rain",
+      },
+      {
+        time: "2026-05-07T14:00",
+        temperatureC: 14,
+        feelsLikeC: 12,
+        precipitationMm: 0.6,
+        precipitationProbabilityPct: 55,
+        conditionCode: 61,
+        conditionLabel: "Rain",
+      },
+    ],
+  };
+};
+
+export const getWeatherTestScenarioSnapshot = (
+  sourceLocationLabel: string,
+): MarkerWeatherSnapshot | null => {
+  const result = getWeatherTestScenarioResult(sourceLocationLabel);
+
+  return result?.type === "snapshot" ? result.snapshot : null;
+};
+
+export const getWeatherTestScenarioResult = (
+  sourceLocationLabel: string,
+): WeatherTestScenarioResult | null => {
+  const scenario = getEnabledScenario();
+
+  if (!scenario) {
+    return null;
+  }
+
+  if (scenario === "unavailable") {
+    return { type: "unavailable" };
+  }
+
+  const snapshot = createBaseSnapshot(sourceLocationLabel);
+
+  if (scenario === "stale") {
+    return {
+      type: "snapshot",
+      snapshot: {
+        ...snapshot,
+        fetchedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      },
+    };
+  }
+
+  if (scenario === "icons") {
+    return {
+      type: "snapshot",
+      snapshot: {
+        ...snapshot,
+        current: snapshot.current
+          ? {
+              ...snapshot.current,
+              temperatureC: 18,
+              feelsLikeC: 18,
+              precipitationProbabilityPct: 0,
+              conditionCode: 0,
+              conditionLabel: "Clear",
+            }
+          : null,
+        upcoming: [
+          {
+            time: "2026-05-07T13:00",
+            temperatureC: 17,
+            feelsLikeC: 17,
+            precipitationMm: 0,
+            precipitationProbabilityPct: 10,
+            conditionCode: 2,
+            conditionLabel: "Partly cloudy",
+          },
+          {
+            time: "2026-05-07T14:00",
+            temperatureC: 16,
+            feelsLikeC: 15,
+            precipitationMm: 0,
+            precipitationProbabilityPct: 15,
+            conditionCode: 3,
+            conditionLabel: "Overcast",
+          },
+          {
+            time: "2026-05-07T15:00",
+            temperatureC: 15,
+            feelsLikeC: 13,
+            precipitationMm: 1.2,
+            precipitationProbabilityPct: 65,
+            conditionCode: 61,
+            conditionLabel: "Rain",
+          },
+          {
+            time: "2026-05-07T16:00",
+            temperatureC: 1,
+            feelsLikeC: -2,
+            precipitationMm: 0.8,
+            precipitationProbabilityPct: 45,
+            conditionCode: 71,
+            conditionLabel: "Snow",
+          },
+          {
+            time: "2026-05-07T17:00",
+            temperatureC: 12,
+            feelsLikeC: 10,
+            precipitationMm: 4,
+            precipitationProbabilityPct: 80,
+            conditionCode: 95,
+            conditionLabel: "Thunderstorm",
+          },
+          {
+            time: "2026-05-07T18:00",
+            temperatureC: 10,
+            feelsLikeC: 9,
+            precipitationMm: 0,
+            precipitationProbabilityPct: 20,
+            conditionCode: 45,
+            conditionLabel: "Fog",
+          },
+          {
+            time: "2026-05-07T19:00",
+            temperatureC: 13,
+            feelsLikeC: 13,
+            precipitationMm: 0,
+            precipitationProbabilityPct: 0,
+            conditionCode: 999,
+            conditionLabel: "Unknown",
+          },
+        ],
+      },
+    };
+  }
+
+  if (scenario === "temperature" || scenario === "temperature-drop") {
+    return {
+      type: "snapshot",
+      snapshot: {
+        ...snapshot,
+        current: snapshot.current
+          ? {
+              ...snapshot.current,
+              temperatureC: 14,
+              feelsLikeC: 13,
+              precipitationProbabilityPct: 20,
+              conditionLabel: "Mainly clear",
+            }
+          : null,
+        upcoming: snapshot.upcoming.map((forecast, index) =>
+          index === 0
+            ? {
+                ...forecast,
+                temperatureC: 7.5,
+                feelsLikeC: 5,
+                precipitationMm: 0,
+                precipitationProbabilityPct: 10,
+                conditionLabel: "Cloudy",
+              }
+            : forecast,
+        ),
+      },
+    };
+  }
+
+  return { type: "snapshot", snapshot };
+};

--- a/src/services/appwrite/__tests__/uploadImages.test.ts
+++ b/src/services/appwrite/__tests__/uploadImages.test.ts
@@ -1,0 +1,85 @@
+import { normalizeUploadableImage } from "@/services/appwrite";
+
+jest.mock("expo-constants", () => ({
+  expoConfig: {
+    extra: {
+      APPWRITE_ENDPOINT: "https://example.com/v1",
+      APPWRITE_PROJECT_ID: "project",
+    },
+  },
+}));
+
+describe("Appwrite upload image normalization", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(1778424000000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("preserves HEIC image names and MIME types from iOS", () => {
+    expect(
+      normalizeUploadableImage({
+        uri: "file:///private/var/mobile/IMG_1234.HEIC",
+        name: "IMG_1234.HEIC",
+        type: "image/heic",
+      }),
+    ).toEqual({
+      uri: "file:///private/var/mobile/IMG_1234.HEIC",
+      name: "IMG_1234.HEIC",
+      type: "image/heic",
+    });
+  });
+
+  it("detects common mobile image MIME types from file extensions", () => {
+    expect(
+      normalizeUploadableImage({
+        uri: "file:///cache/photo.heif",
+        name: "photo.heif",
+        type: null,
+      }),
+    ).toMatchObject({
+      name: "photo.heif",
+      type: "image/heif",
+    });
+
+    expect(
+      normalizeUploadableImage({
+        uri: "file:///cache/photo.webp",
+        name: "photo.webp",
+      }),
+    ).toMatchObject({
+      name: "photo.webp",
+      type: "image/webp",
+    });
+  });
+
+  it("uses URI extensions when the picker does not provide a filename", () => {
+    expect(
+      normalizeUploadableImage({
+        uri: "file:///cache/selected-image.PNG",
+        name: null,
+        type: null,
+      }),
+    ).toEqual({
+      uri: "file:///cache/selected-image.PNG",
+      name: "upload-1778424000000.png",
+      type: "image/png",
+    });
+  });
+
+  it("adds a supported extension when the picker filename is missing one", () => {
+    expect(
+      normalizeUploadableImage({
+        uri: "ph://asset-id",
+        name: "marker-photo",
+        type: "image/heic",
+      }),
+    ).toEqual({
+      uri: "ph://asset-id",
+      name: "marker-photo.heic",
+      type: "image/heic",
+    });
+  });
+});

--- a/src/services/appwrite/index.ts
+++ b/src/services/appwrite/index.ts
@@ -23,8 +23,8 @@ type ExpoExtra = {
 
 export type UploadableImage = {
   uri: string;
-  name: string;
-  type: string;
+  name?: string | null;
+  type?: string | null;
   size?: number;
 };
 
@@ -349,11 +349,74 @@ const normalizeUploadFileName = (value: string | undefined, fallback: string) =>
   return normalized || fallback;
 };
 
-const buildUploadPayload = (file: UploadableImage) => ({
-  uri: file.uri,
-  name: normalizeUploadFileName(file.name, `upload-${Date.now()}.jpg`),
-  type: file.type || "image/jpeg",
-});
+const SUPPORTED_IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+  gif: "image/gif",
+  heic: "image/heic",
+  heif: "image/heif",
+  bmp: "image/bmp",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+};
+
+const MIME_EXTENSION_BY_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "image/bmp": "bmp",
+  "image/tiff": "tiff",
+  "image/x-heic": "heic",
+  "image/x-heif": "heif",
+};
+
+const getFileExtension = (value?: string | null) => {
+  const match = value?.trim().match(/\.([a-zA-Z0-9]+)(?:[?#].*)?$/u);
+  return match?.[1]?.toLowerCase() ?? null;
+};
+
+const normalizeImageMimeType = (file: UploadableImage) => {
+  const declaredType = file.type?.trim().toLowerCase();
+  const typeFromName = getFileExtension(file.name);
+  const typeFromUri = getFileExtension(file.uri);
+  const extension = typeFromName ?? typeFromUri;
+
+  if (declaredType && MIME_EXTENSION_BY_TYPE[declaredType]) {
+    return SUPPORTED_IMAGE_MIME_BY_EXTENSION[MIME_EXTENSION_BY_TYPE[declaredType]];
+  }
+
+  return extension
+    ? (SUPPORTED_IMAGE_MIME_BY_EXTENSION[extension] ?? "image/jpeg")
+    : "image/jpeg";
+};
+
+export const normalizeUploadableImage = (file: UploadableImage) => {
+  const mimeType = normalizeImageMimeType(file);
+  const declaredExtension = getFileExtension(file.name);
+  const uriExtension = getFileExtension(file.uri);
+  const fallbackExtension =
+    MIME_EXTENSION_BY_TYPE[mimeType] ?? declaredExtension ?? uriExtension ?? "jpg";
+  const baseName = normalizeUploadFileName(
+    file.name ?? undefined,
+    `upload-${Date.now()}.${fallbackExtension}`,
+  );
+  const hasSupportedExtension = Boolean(
+    SUPPORTED_IMAGE_MIME_BY_EXTENSION[getFileExtension(baseName) ?? ""],
+  );
+  const name = hasSupportedExtension ? baseName : `${baseName}.${fallbackExtension}`;
+
+  return {
+    uri: file.uri,
+    name,
+    type: mimeType,
+  };
+};
 
 const createStorageFile = async (
   file: UploadableImage,
@@ -365,7 +428,7 @@ const createStorageFile = async (
     const formData = new FormData();
 
     formData.append("fileId", "unique()");
-    formData.append("file", buildUploadPayload(file) as unknown as Blob);
+    formData.append("file", normalizeUploadableImage(file) as unknown as Blob);
     permissions.forEach((permission) => {
       formData.append("permissions[]", permission);
     });

--- a/src/services/weather/__tests__/openMeteo.test.ts
+++ b/src/services/weather/__tests__/openMeteo.test.ts
@@ -1,0 +1,117 @@
+import { buildOpenMeteoForecastUrl, normalizeOpenMeteoWeather } from "@/services/weather";
+
+describe("Open-Meteo weather service", () => {
+  it("builds a compact forecast URL for marker coordinates", () => {
+    const url = buildOpenMeteoForecastUrl({
+      coordinate: { latitude: 54.6872, longitude: 25.2797 },
+      upcomingHours: 4,
+    });
+
+    expect(url).toContain("https://api.open-meteo.com/v1/forecast?");
+    expect(url).toContain("latitude=54.6872");
+    expect(url).toContain("longitude=25.2797");
+    expect(url).toContain("timezone=auto");
+    expect(url).toContain("forecast_hours=5");
+    expect(url).toContain("models=icon_eu");
+    expect(url).toContain("current=temperature_2m");
+    expect(url).toContain("hourly=temperature_2m");
+  });
+
+  it("normalizes current conditions and the next forecast hours", () => {
+    const snapshot = normalizeOpenMeteoWeather(
+      {
+        timezone: "Europe/Vilnius",
+        current: {
+          time: "2026-05-01T12:00",
+          temperature_2m: 14.7,
+          apparent_temperature: 13.8,
+          precipitation: 0,
+          precipitation_probability: 20,
+          weather_code: 61,
+          wind_speed_10m: 12.4,
+          relative_humidity_2m: 71,
+          cloud_cover: 88,
+        },
+        hourly: {
+          time: [
+            "2026-05-01T12:00",
+            "2026-05-01T13:00",
+            "2026-05-01T14:00",
+            "2026-05-01T15:00",
+            "2026-05-01T16:00",
+            "2026-05-01T17:00",
+          ],
+          temperature_2m: [14.7, 15.1, 15.4, 14.9, 14.2, 13.6],
+          apparent_temperature: [12.7, 12.5, 12.2, 11.8, 11.3, 10.9],
+          precipitation: [0, 0.1, 0.2, 0, 0, 0.4],
+          precipitation_probability: [20, 25, 40, 30, 20, 55],
+          weather_code: [61, 61, 63, 3, 2, 80],
+        },
+      },
+      {
+        fetchedAt: "2026-05-01T09:15:00.000Z",
+        sourceLocationLabel: "Bench near Cathedral",
+        upcomingHours: 4,
+      },
+    );
+
+    expect(snapshot).toMatchObject({
+      provider: "open-meteo",
+      sourceLocationLabel: "Bench near Cathedral",
+      fetchedAt: "2026-05-01T09:15:00.000Z",
+      current: {
+        time: "2026-05-01T12:00",
+        temperatureC: 14.7,
+        feelsLikeC: 13.8,
+        precipitationMm: 0,
+        precipitationProbabilityPct: 20,
+        windSpeedKmh: 12.4,
+        humidityPct: 71,
+        cloudCoverPct: 88,
+        conditionCode: 61,
+        conditionLabel: "Rain",
+      },
+    });
+    expect(snapshot.upcoming).toHaveLength(4);
+    expect(snapshot.upcoming[0]).toEqual({
+      time: "2026-05-01T13:00",
+      temperatureC: 15.1,
+      feelsLikeC: 12.5,
+      precipitationMm: 0.1,
+      precipitationProbabilityPct: 25,
+      conditionCode: 61,
+      conditionLabel: "Rain",
+    });
+    expect(snapshot.upcoming[3].time).toBe("2026-05-01T16:00");
+  });
+
+  it("handles missing optional weather fields", () => {
+    const snapshot = normalizeOpenMeteoWeather(
+      {
+        current: {
+          time: "2026-05-01T12:00",
+          weather_code: 999,
+        },
+        hourly: {
+          time: ["2026-05-01T13:00"],
+          weather_code: [0],
+        },
+      },
+      { fetchedAt: "2026-05-01T09:15:00.000Z" },
+    );
+
+    expect(snapshot.current).toMatchObject({
+      temperatureC: null,
+      conditionCode: 999,
+      conditionLabel: "Unknown",
+    });
+    expect(snapshot.upcoming[0]).toMatchObject({
+      temperatureC: null,
+      feelsLikeC: null,
+      precipitationMm: null,
+      precipitationProbabilityPct: null,
+      conditionCode: 0,
+      conditionLabel: "Clear",
+    });
+  });
+});

--- a/src/services/weather/__tests__/openMeteo.test.ts
+++ b/src/services/weather/__tests__/openMeteo.test.ts
@@ -1,6 +1,22 @@
-import { buildOpenMeteoForecastUrl, normalizeOpenMeteoWeather } from "@/services/weather";
+import {
+  buildOpenMeteoForecastUrl,
+  fetchOpenMeteoWeatherSnapshot,
+  normalizeOpenMeteoWeather,
+  WeatherProviderError,
+} from "@/services/weather";
 
 describe("Open-Meteo weather service", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
   it("builds a compact forecast URL for marker coordinates", () => {
     const url = buildOpenMeteoForecastUrl({
       coordinate: { latitude: 54.6872, longitude: 25.2797 },
@@ -12,7 +28,7 @@ describe("Open-Meteo weather service", () => {
     expect(url).toContain("longitude=25.2797");
     expect(url).toContain("timezone=auto");
     expect(url).toContain("forecast_hours=5");
-    expect(url).toContain("models=icon_eu");
+    expect(url).not.toContain("models=");
     expect(url).toContain("current=temperature_2m");
     expect(url).toContain("hourly=temperature_2m");
   });
@@ -113,5 +129,66 @@ describe("Open-Meteo weather service", () => {
       conditionCode: 0,
       conditionLabel: "Clear",
     });
+  });
+
+  it("uses one best-match request instead of serial model retries", async () => {
+    const mockedFetch = jest.mocked(global.fetch);
+
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        current: {
+          time: "2026-05-01T12:00",
+          temperature_2m: 14,
+          apparent_temperature: 13,
+          precipitation: 0,
+          precipitation_probability: 20,
+          weather_code: 61,
+          wind_speed_10m: 12,
+          relative_humidity_2m: 70,
+          cloud_cover: 80,
+        },
+        hourly: {
+          time: ["2026-05-01T12:00", "2026-05-01T13:00"],
+          temperature_2m: [14, 15],
+          apparent_temperature: [13, 14],
+          precipitation: [0, 0.1],
+          precipitation_probability: [20, 25],
+          weather_code: [61, 61],
+        },
+      }),
+    } as Response);
+
+    await fetchOpenMeteoWeatherSnapshot({
+      coordinate: { latitude: 54.6872, longitude: 25.2797 },
+      sourceLocationLabel: "Bench near Cathedral",
+      upcomingHours: 4,
+    });
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(String(mockedFetch.mock.calls[0]?.[0])).not.toContain("models=");
+  });
+
+  it("throws a provider error when the best-match request fails", async () => {
+    const mockedFetch = jest.mocked(global.fetch);
+
+    mockedFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+    } as Response);
+
+    await expect(
+      fetchOpenMeteoWeatherSnapshot({
+        coordinate: { latitude: 54.6872, longitude: 25.2797 },
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<WeatherProviderError>>({
+        name: "WeatherProviderError",
+        message: "Weather forecast is temporarily unavailable.",
+        status: 502,
+      }),
+    );
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/weather/index.ts
+++ b/src/services/weather/index.ts
@@ -1,0 +1,17 @@
+export {
+  buildOpenMeteoForecastUrl,
+  fetchOpenMeteoWeatherSnapshot,
+  normalizeOpenMeteoWeather,
+  openMeteoWeatherProvider,
+  WeatherProviderError,
+} from "./openMeteo";
+export type { WeatherProvider } from "./provider";
+export type {
+  FetchWeatherSnapshotInput,
+  MarkerWeatherSnapshot,
+  WeatherConditionCode,
+  WeatherCoordinate,
+  WeatherCurrentConditions,
+  WeatherForecastHour,
+  WeatherProviderId,
+} from "./types";

--- a/src/services/weather/openMeteo.ts
+++ b/src/services/weather/openMeteo.ts
@@ -8,9 +8,7 @@ import type {
 
 const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
 const DEFAULT_UPCOMING_HOURS = 4;
-const OPEN_METEO_MODELS = ["icon_eu", "ecmwf_ifs025", "icon_global"] as const;
 const WEATHER_REQUEST_TIMEOUT_MS = 8000;
-type OpenMeteoModel = (typeof OPEN_METEO_MODELS)[number];
 
 const CURRENT_FIELDS = [
   "temperature_2m",
@@ -194,10 +192,10 @@ const buildUpcomingForecast = (
     .slice(0, upcomingHours);
 };
 
-export const buildOpenMeteoForecastUrl = (
-  { coordinate, upcomingHours }: FetchWeatherSnapshotInput,
-  model: OpenMeteoModel = OPEN_METEO_MODELS[0],
-): string => {
+export const buildOpenMeteoForecastUrl = ({
+  coordinate,
+  upcomingHours,
+}: FetchWeatherSnapshotInput): string => {
   const forecastHours = clampUpcomingHours(upcomingHours) + 1;
   const params = new URLSearchParams({
     latitude: String(coordinate.latitude),
@@ -206,7 +204,6 @@ export const buildOpenMeteoForecastUrl = (
     hourly: HOURLY_FIELDS.join(","),
     timezone: "auto",
     forecast_hours: String(forecastHours),
-    models: model,
     temperature_unit: "celsius",
     wind_speed_unit: "kmh",
     precipitation_unit: "mm",
@@ -249,34 +246,28 @@ export const normalizeOpenMeteoWeather = (
 export const fetchOpenMeteoWeatherSnapshot = async (
   input: FetchWeatherSnapshotInput,
 ): Promise<MarkerWeatherSnapshot> => {
-  let lastError: unknown = null;
+  try {
+    const response = await fetchWithTimeout(buildOpenMeteoForecastUrl(input));
 
-  for (const model of OPEN_METEO_MODELS) {
-    try {
-      const response = await fetchWithTimeout(buildOpenMeteoForecastUrl(input, model));
-
-      if (!response.ok) {
-        throw new WeatherProviderError(
-          "Weather forecast is temporarily unavailable.",
-          response.status,
-        );
-      }
-
-      const data = (await response.json()) as OpenMeteoForecastResponse;
-      return normalizeOpenMeteoWeather(data, {
-        sourceLocationLabel: input.sourceLocationLabel,
-        upcomingHours: input.upcomingHours,
-      });
-    } catch (error) {
-      lastError = error;
+    if (!response.ok) {
+      throw new WeatherProviderError(
+        "Weather forecast is temporarily unavailable.",
+        response.status,
+      );
     }
-  }
 
-  if (lastError instanceof WeatherProviderError) {
-    throw lastError;
-  }
+    const data = (await response.json()) as OpenMeteoForecastResponse;
+    return normalizeOpenMeteoWeather(data, {
+      sourceLocationLabel: input.sourceLocationLabel,
+      upcomingHours: input.upcomingHours,
+    });
+  } catch (error) {
+    if (error instanceof WeatherProviderError) {
+      throw error;
+    }
 
-  throw new WeatherProviderError("Weather forecast is temporarily unavailable.");
+    throw new WeatherProviderError("Weather forecast is temporarily unavailable.");
+  }
 };
 
 export const openMeteoWeatherProvider = {

--- a/src/services/weather/openMeteo.ts
+++ b/src/services/weather/openMeteo.ts
@@ -1,0 +1,284 @@
+import type {
+  FetchWeatherSnapshotInput,
+  MarkerWeatherSnapshot,
+  WeatherConditionCode,
+  WeatherCurrentConditions,
+  WeatherForecastHour,
+} from "./types";
+
+const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const DEFAULT_UPCOMING_HOURS = 4;
+const OPEN_METEO_MODELS = ["icon_eu", "ecmwf_ifs025", "icon_global"] as const;
+const WEATHER_REQUEST_TIMEOUT_MS = 8000;
+type OpenMeteoModel = (typeof OPEN_METEO_MODELS)[number];
+
+const CURRENT_FIELDS = [
+  "temperature_2m",
+  "relative_humidity_2m",
+  "apparent_temperature",
+  "precipitation",
+  "precipitation_probability",
+  "weather_code",
+  "cloud_cover",
+  "wind_speed_10m",
+];
+
+const HOURLY_FIELDS = [
+  "temperature_2m",
+  "apparent_temperature",
+  "precipitation",
+  "precipitation_probability",
+  "weather_code",
+];
+
+type OpenMeteoForecastResponse = {
+  current?: unknown;
+  hourly?: unknown;
+  timezone?: unknown;
+};
+
+type NormalizeOpenMeteoOptions = {
+  fetchedAt?: string;
+  sourceLocationLabel?: string;
+  upcomingHours?: number;
+};
+
+export class WeatherProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "WeatherProviderError";
+  }
+}
+
+const clampUpcomingHours = (hours?: number) => {
+  if (!Number.isFinite(hours)) {
+    return DEFAULT_UPCOMING_HOURS;
+  }
+
+  return Math.max(1, Math.min(24, Math.floor(hours as number)));
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" ? value : null;
+
+const asNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const readArrayValue = (
+  record: Record<string, unknown> | null,
+  key: string,
+  index: number,
+) => {
+  const value = record?.[key];
+  return Array.isArray(value) ? value[index] : null;
+};
+
+const getOpenMeteoConditionLabel = (code: WeatherConditionCode): string => {
+  switch (code) {
+    case 0:
+      return "Clear";
+    case 1:
+      return "Mainly clear";
+    case 2:
+      return "Partly cloudy";
+    case 3:
+      return "Overcast";
+    case 45:
+    case 48:
+      return "Fog";
+    case 51:
+    case 53:
+    case 55:
+      return "Drizzle";
+    case 56:
+    case 57:
+      return "Freezing drizzle";
+    case 61:
+    case 63:
+    case 65:
+      return "Rain";
+    case 66:
+    case 67:
+      return "Freezing rain";
+    case 71:
+    case 73:
+    case 75:
+      return "Snow";
+    case 77:
+      return "Snow grains";
+    case 80:
+    case 81:
+    case 82:
+      return "Rain showers";
+    case 85:
+    case 86:
+      return "Snow showers";
+    case 95:
+      return "Thunderstorm";
+    case 96:
+    case 99:
+      return "Thunderstorm with hail";
+    default:
+      return "Unknown";
+  }
+};
+
+const buildCurrentConditions = (
+  current: Record<string, unknown> | null,
+): WeatherCurrentConditions | null => {
+  if (!current) {
+    return null;
+  }
+
+  const conditionCode = asNumber(current.weather_code);
+
+  return {
+    time: asString(current.time),
+    temperatureC: asNumber(current.temperature_2m),
+    feelsLikeC: asNumber(current.apparent_temperature),
+    precipitationMm: asNumber(current.precipitation),
+    precipitationProbabilityPct: asNumber(current.precipitation_probability),
+    windSpeedKmh: asNumber(current.wind_speed_10m),
+    humidityPct: asNumber(current.relative_humidity_2m),
+    cloudCoverPct: asNumber(current.cloud_cover),
+    conditionCode,
+    conditionLabel: getOpenMeteoConditionLabel(conditionCode),
+  };
+};
+
+const buildUpcomingForecast = (
+  hourly: Record<string, unknown> | null,
+  currentTime: string | null,
+  upcomingHours: number,
+): WeatherForecastHour[] => {
+  const times = hourly?.time;
+
+  if (!Array.isArray(times)) {
+    return [];
+  }
+
+  return times
+    .map((time, index): WeatherForecastHour | null => {
+      const forecastTime = asString(time);
+
+      if (!forecastTime || (currentTime && forecastTime <= currentTime)) {
+        return null;
+      }
+
+      const conditionCode = asNumber(readArrayValue(hourly, "weather_code", index));
+
+      return {
+        time: forecastTime,
+        temperatureC: asNumber(readArrayValue(hourly, "temperature_2m", index)),
+        feelsLikeC: asNumber(readArrayValue(hourly, "apparent_temperature", index)),
+        precipitationMm: asNumber(readArrayValue(hourly, "precipitation", index)),
+        precipitationProbabilityPct: asNumber(
+          readArrayValue(hourly, "precipitation_probability", index),
+        ),
+        conditionCode,
+        conditionLabel: getOpenMeteoConditionLabel(conditionCode),
+      };
+    })
+    .filter((forecast): forecast is WeatherForecastHour => forecast !== null)
+    .slice(0, upcomingHours);
+};
+
+export const buildOpenMeteoForecastUrl = (
+  { coordinate, upcomingHours }: FetchWeatherSnapshotInput,
+  model: OpenMeteoModel = OPEN_METEO_MODELS[0],
+): string => {
+  const forecastHours = clampUpcomingHours(upcomingHours) + 1;
+  const params = new URLSearchParams({
+    latitude: String(coordinate.latitude),
+    longitude: String(coordinate.longitude),
+    current: CURRENT_FIELDS.join(","),
+    hourly: HOURLY_FIELDS.join(","),
+    timezone: "auto",
+    forecast_hours: String(forecastHours),
+    models: model,
+    temperature_unit: "celsius",
+    wind_speed_unit: "kmh",
+    precipitation_unit: "mm",
+  });
+
+  return `${OPEN_METEO_FORECAST_URL}?${params.toString()}`;
+};
+
+const fetchWithTimeout = async (url: string): Promise<Response> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), WEATHER_REQUEST_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+export const normalizeOpenMeteoWeather = (
+  response: OpenMeteoForecastResponse,
+  options: NormalizeOpenMeteoOptions = {},
+): MarkerWeatherSnapshot => {
+  const upcomingHours = clampUpcomingHours(options.upcomingHours);
+  const current = buildCurrentConditions(asRecord(response.current));
+
+  return {
+    provider: "open-meteo",
+    sourceLocationLabel: options.sourceLocationLabel ?? "Selected marker",
+    fetchedAt: options.fetchedAt ?? new Date().toISOString(),
+    current,
+    upcoming: buildUpcomingForecast(
+      asRecord(response.hourly),
+      current?.time ?? null,
+      upcomingHours,
+    ),
+  };
+};
+
+export const fetchOpenMeteoWeatherSnapshot = async (
+  input: FetchWeatherSnapshotInput,
+): Promise<MarkerWeatherSnapshot> => {
+  let lastError: unknown = null;
+
+  for (const model of OPEN_METEO_MODELS) {
+    try {
+      const response = await fetchWithTimeout(buildOpenMeteoForecastUrl(input, model));
+
+      if (!response.ok) {
+        throw new WeatherProviderError(
+          "Weather forecast is temporarily unavailable.",
+          response.status,
+        );
+      }
+
+      const data = (await response.json()) as OpenMeteoForecastResponse;
+      return normalizeOpenMeteoWeather(data, {
+        sourceLocationLabel: input.sourceLocationLabel,
+        upcomingHours: input.upcomingHours,
+      });
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError instanceof WeatherProviderError) {
+    throw lastError;
+  }
+
+  throw new WeatherProviderError("Weather forecast is temporarily unavailable.");
+};
+
+export const openMeteoWeatherProvider = {
+  fetchWeatherSnapshot: fetchOpenMeteoWeatherSnapshot,
+};

--- a/src/services/weather/provider.ts
+++ b/src/services/weather/provider.ts
@@ -1,0 +1,7 @@
+import type { FetchWeatherSnapshotInput, MarkerWeatherSnapshot } from "./types";
+
+export interface WeatherProvider {
+  fetchWeatherSnapshot: (
+    input: FetchWeatherSnapshotInput,
+  ) => Promise<MarkerWeatherSnapshot>;
+}

--- a/src/services/weather/types.ts
+++ b/src/services/weather/types.ts
@@ -1,0 +1,46 @@
+export type WeatherProviderId = "open-meteo" | "meteo-lt";
+
+export type WeatherCoordinate = {
+  latitude: number;
+  longitude: number;
+};
+
+export type WeatherConditionCode = string | number | null;
+
+export type WeatherCurrentConditions = {
+  time: string | null;
+  temperatureC: number | null;
+  feelsLikeC: number | null;
+  precipitationMm: number | null;
+  precipitationProbabilityPct: number | null;
+  windSpeedKmh: number | null;
+  humidityPct: number | null;
+  cloudCoverPct: number | null;
+  conditionCode: WeatherConditionCode;
+  conditionLabel: string;
+};
+
+export type WeatherForecastHour = {
+  time: string;
+  temperatureC: number | null;
+  feelsLikeC: number | null;
+  precipitationMm: number | null;
+  precipitationProbabilityPct: number | null;
+  conditionCode: WeatherConditionCode;
+  conditionLabel: string;
+};
+
+export type MarkerWeatherSnapshot = {
+  provider: WeatherProviderId;
+  sourceLocationLabel: string;
+  sourceDistanceKm?: number;
+  fetchedAt: string;
+  current: WeatherCurrentConditions | null;
+  upcoming: WeatherForecastHour[];
+};
+
+export type FetchWeatherSnapshotInput = {
+  coordinate: WeatherCoordinate;
+  sourceLocationLabel?: string;
+  upcomingHours?: number;
+};

--- a/src/shared/components/ImageLoadingPlaceholder.tsx
+++ b/src/shared/components/ImageLoadingPlaceholder.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { ActivityIndicator, StyleSheet, View, type ViewStyle } from "react-native";
+
+interface ImageLoadingPlaceholderProps {
+  fill?: boolean;
+  className?: string;
+  style?: ViewStyle;
+}
+
+const ImageLoadingPlaceholder: React.FC<ImageLoadingPlaceholderProps> = ({
+  fill = false,
+  className,
+  style,
+}) => (
+  <View
+    className={className}
+    style={[styles.container, fill ? StyleSheet.absoluteFillObject : null, style]}
+    accessibilityRole="progressbar"
+  >
+    <ActivityIndicator color="#64748B" size="small" />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    backgroundColor: "#E2E8F0",
+  },
+});
+
+export default ImageLoadingPlaceholder;

--- a/src/shared/components/PhotoLightbox.tsx
+++ b/src/shared/components/PhotoLightbox.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
+  ActivityIndicator,
   FlatList,
   Image,
   Modal,
@@ -39,6 +40,7 @@ interface ZoomablePhotoProps {
 }
 
 const ZoomablePhoto: React.FC<ZoomablePhotoProps> = ({ uri, width, height }) => {
+  const [isLoading, setIsLoading] = useState(true);
   const scale = useSharedValue(1);
   const savedScale = useSharedValue(1);
   const translateX = useSharedValue(0);
@@ -53,6 +55,7 @@ const ZoomablePhoto: React.FC<ZoomablePhotoProps> = ({ uri, width, height }) => 
     translateY.value = 0;
     savedTranslateX.value = 0;
     savedTranslateY.value = 0;
+    setIsLoading(true);
   }, [savedScale, savedTranslateX, savedTranslateY, scale, translateX, translateY, uri]);
 
   const pinchGesture = useMemo(
@@ -118,11 +121,20 @@ const ZoomablePhoto: React.FC<ZoomablePhotoProps> = ({ uri, width, height }) => 
             resizeMode="contain"
             style={{
               width: width - 32,
-              height: height - 160,
+              height,
             }}
+            onLoadStart={() => setIsLoading(true)}
+            onLoadEnd={() => setIsLoading(false)}
           />
         </Animated.View>
       </GestureDetector>
+      {isLoading ? (
+        <View className="absolute inset-0 items-center justify-center">
+          <View className="bg-black/55 h-12 w-12 items-center justify-center rounded-full">
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          </View>
+        </View>
+      ) : null}
     </View>
   );
 };
@@ -137,6 +149,9 @@ const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
   const { width, height } = useWindowDimensions();
   const listRef = useRef<FlatList<string> | null>(null);
   const [activeIndex, setActiveIndex] = useState(initialIndex);
+  const imageFrameHeight = Math.max(280, height - 188);
+  const canGoPrevious = activeIndex > 0;
+  const canGoNext = activeIndex < photos.length - 1;
 
   useEffect(() => {
     if (!visible) {
@@ -159,6 +174,15 @@ const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     setActiveIndex(nextIndex);
   };
 
+  const goToPhoto = (index: number) => {
+    const nextIndex = Math.min(Math.max(index, 0), photos.length - 1);
+    setActiveIndex(nextIndex);
+    listRef.current?.scrollToIndex({
+      index: nextIndex,
+      animated: true,
+    });
+  };
+
   if (!visible || photos.length === 0) {
     return null;
   }
@@ -175,7 +199,7 @@ const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
         <View className="flex-1 bg-black/95">
           <Pressable className="absolute inset-0" onPress={onClose} />
 
-          <View className="px-5 pb-4 pt-16">
+          <View className="px-5 pb-3 pt-14">
             <View className="flex-row items-center justify-between">
               <View className="flex-1 pr-4">
                 {title ? (
@@ -183,9 +207,6 @@ const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
                     {title}
                   </Text>
                 ) : null}
-                <Text className="mt-1 font-pregular text-sm text-slate-300">
-                  {activeIndex + 1} / {photos.length}
-                </Text>
               </View>
 
               <Pressable
@@ -199,28 +220,82 @@ const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
             </View>
           </View>
 
-          <FlatList
-            ref={listRef}
-            data={photos}
-            horizontal
-            pagingEnabled
-            keyExtractor={(item, index) => `${item}-${index}`}
-            showsHorizontalScrollIndicator={false}
-            initialNumToRender={1}
-            maxToRenderPerBatch={1}
-            windowSize={2}
-            removeClippedSubviews
-            onScrollToIndexFailed={() => {}}
-            onMomentumScrollEnd={handleScrollEnd}
-            getItemLayout={(_, index) => ({
-              length: width,
-              offset: width * index,
-              index,
-            })}
-            renderItem={({ item }) => (
-              <ZoomablePhoto uri={item} width={width} height={height} />
-            )}
-          />
+          <View className="flex-1 justify-center">
+            <FlatList
+              ref={listRef}
+              data={photos}
+              horizontal
+              pagingEnabled
+              keyExtractor={(item, index) => `${item}-${index}`}
+              showsHorizontalScrollIndicator={false}
+              initialNumToRender={1}
+              maxToRenderPerBatch={1}
+              windowSize={2}
+              removeClippedSubviews
+              onScrollToIndexFailed={() => {}}
+              onMomentumScrollEnd={handleScrollEnd}
+              getItemLayout={(_, index) => ({
+                length: width,
+                offset: width * index,
+                index,
+              })}
+              renderItem={({ item }) => (
+                <ZoomablePhoto uri={item} width={width} height={imageFrameHeight} />
+              )}
+            />
+          </View>
+
+          {photos.length > 1 ? (
+            <View className="flex-row items-center justify-center gap-4 px-5 pb-9 pt-3">
+              <Pressable
+                onPress={() => goToPhoto(activeIndex - 1)}
+                disabled={!canGoPrevious}
+                className={`h-12 w-12 items-center justify-center rounded-full ${
+                  canGoPrevious ? "bg-white/12" : "bg-white/5"
+                }`}
+                accessibilityRole="button"
+                accessibilityLabel="Previous image"
+                accessibilityState={{ disabled: !canGoPrevious }}
+              >
+                <MaterialIcons
+                  name="chevron-left"
+                  size={28}
+                  color={canGoPrevious ? "#FFFFFF" : "#64748B"}
+                />
+              </Pressable>
+
+              <View className="min-w-[72px] items-center rounded-full bg-white/10 px-4 py-2">
+                <Text className="font-pmedium text-sm text-white">
+                  {activeIndex + 1} / {photos.length}
+                </Text>
+              </View>
+
+              <Pressable
+                onPress={() => goToPhoto(activeIndex + 1)}
+                disabled={!canGoNext}
+                className={`h-12 w-12 items-center justify-center rounded-full ${
+                  canGoNext ? "bg-white/12" : "bg-white/5"
+                }`}
+                accessibilityRole="button"
+                accessibilityLabel="Next image"
+                accessibilityState={{ disabled: !canGoNext }}
+              >
+                <MaterialIcons
+                  name="chevron-right"
+                  size={28}
+                  color={canGoNext ? "#FFFFFF" : "#64748B"}
+                />
+              </Pressable>
+            </View>
+          ) : (
+            <View className="items-center px-5 pb-9 pt-3">
+              <View className="min-w-[72px] items-center rounded-full bg-white/10 px-4 py-2">
+                <Text className="font-pmedium text-sm text-white">
+                  {activeIndex + 1} / {photos.length}
+                </Text>
+              </View>
+            </View>
+          )}
         </View>
       </GestureHandlerRootView>
     </Modal>

--- a/src/shared/components/__tests__/PhotoLightbox.test.tsx
+++ b/src/shared/components/__tests__/PhotoLightbox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 
 import PhotoLightbox from "../PhotoLightbox";
 
@@ -55,5 +55,26 @@ describe("PhotoLightbox", () => {
 
     expect(getByText("Bench by the river")).toBeTruthy();
     expect(getByText("1 / 1")).toBeTruthy();
+  });
+
+  it("navigates between multiple images with explicit controls", () => {
+    const { getByLabelText, getByText } = render(
+      <PhotoLightbox
+        visible
+        photos={["https://example.com/photo-1.jpg", "https://example.com/photo-2.jpg"]}
+        title="Bench by the river"
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(getByText("1 / 2")).toBeTruthy();
+
+    fireEvent.press(getByLabelText("Next image"));
+
+    expect(getByText("2 / 2")).toBeTruthy();
+
+    fireEvent.press(getByLabelText("Previous image"));
+
+    expect(getByText("1 / 2")).toBeTruthy();
   });
 });

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -7,6 +7,7 @@ export { ExternalLink } from "./ExternalLink";
 export { default as FormField } from "./FormField";
 export { HelloWave } from "./HelloWave";
 export { default as InfoBox } from "./InfoBox";
+export { default as ImageLoadingPlaceholder } from "./ImageLoadingPlaceholder";
 export { default as Loader } from "./Loader";
 export { default as NoticeBanner } from "./NoticeBanner";
 export { default as Pagination } from "./Pagination";


### PR DESCRIPTION
## What changed

Added a weather service for fetching forecast data from Open-Meteo.
- Added weather-domain utilities for caching, icon mapping, weather changes, and test scenarios.
- Added `useMarkerWeather` hook to load weather for a selected marker.
- Added `MarkerWeatherCard` UI for displaying marker weather context.
- Added tests for the weather service, hook, UI component, and weather utility logic.

## Notes for reviewers

Mention anything reviewers should focus on, verify, or be aware of.
